### PR TITLE
fix(security): resolve all Dependabot alerts

### DIFF
--- a/purchasely/example/package-lock.json
+++ b/purchasely/example/package-lock.json
@@ -19,7 +19,7 @@
     },
     "..": {
       "name": "@purchasely/cordova-plugin-purchasely",
-      "version": "5.6.2",
+      "version": "5.7.2",
       "dev": true,
       "license": "ISC",
       "devDependencies": {
@@ -36,7 +36,7 @@
     },
     "../../purchasely-google": {
       "name": "@purchasely/cordova-plugin-purchasely-google",
-      "version": "5.6.2",
+      "version": "5.7.2",
       "dev": true,
       "license": "ISC"
     },
@@ -91,7 +91,9 @@
       "link": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -558,9 +560,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -679,7 +681,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/purchasely/package-lock.json
+++ b/purchasely/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@purchasely/cordova-plugin-purchasely",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@purchasely/cordova-plugin-purchasely",
-      "version": "5.7.1",
+      "version": "5.7.2",
       "license": "ISC",
       "devDependencies": {
         "jest": "^29.7.0"
@@ -1228,9 +1228,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3054,9 +3054,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- **picomatch** 2.3.1 → 2.3.2 — fixes ReDoS via extglob quantifiers (CVE-2026-33671) and method injection in POSIX character classes (CVE-2026-33672)
- **lodash** 4.17.23 → 4.18.1 — fixes Prototype Pollution via `_.unset`/`_.omit` (CVE-2026-2950) and Code Injection via `_.template` (CVE-2026-4800)
- **@xmldom/xmldom** 0.8.11 → 0.8.12 — fixes XML injection via unsafe CDATA serialization (CVE-2026-34601)
- **brace-expansion** 1.1.12 → 1.1.14 — fixes zero-step sequence hang

Resolves Dependabot alerts #10, #11, #12, #13, #14, #15, #16.

All are transitive dev dependencies — no impact on the published plugin.

## Test plan

- [x] `npm audit` returns 0 vulnerabilities in `purchasely/`
- [x] `npm audit` returns 0 vulnerabilities in `purchasely/example/`
- [x] CI passes (iOS build, Android build, version check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)