### PR TITLE
fix(security): resolve Dependabot xmldom alerts

### DIFF
--- a/purchasely/example/package-lock.json
+++ b/purchasely/example/package-lock.json
@@ -91,13 +91,13 @@
       "link": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/abbrev": {

--- a/purchasely/example/package-lock.json
+++ b/purchasely/example/package-lock.json
@@ -704,11 +704,13 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.1.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
+        "@xmldom/xmldom": "^0.9.10",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },

--- a/purchasely/example/package.json
+++ b/purchasely/example/package.json
@@ -20,6 +20,9 @@
     "cordova-plugin-purchasely": "file:..",
     "cordova-plugin-purchasely-google": "file:../../purchasely-google"
   },
+  "overrides": {
+    "@xmldom/xmldom": "^0.9.8"
+  },
   "cordova": {
     "plugins": {
       "@purchasely/cordova-plugin-purchasely-google": {}

--- a/purchasely/example/package.json
+++ b/purchasely/example/package.json
@@ -21,7 +21,8 @@
     "cordova-plugin-purchasely-google": "file:../../purchasely-google"
   },
   "overrides": {
-    "@xmldom/xmldom": "^0.9.8"
+    "@xmldom/xmldom": "^0.9.8",
+    "plist": "^3.1.1"
   },
   "cordova": {
     "plugins": {


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` entry forcing `@xmldom/xmldom@^0.9.8` in `purchasely/example` (resolves to `0.9.10`).
- The vulnerable `0.8.12` was pulled transitively via `cordova-ios@8.0.0` → `plist@3.1.0`.

## Alertes Dependabot corrigées
- #17 — XML node injection via processing instruction serialization (high)
- #18 — XML injection via DocumentType serialization (high)
- #19 — XML node injection via comment serialization (high)
- #20 — Uncontrolled recursion in XML serialization / DoS (high)

## Test plan
- [x] `npm install --package-lock-only` regenerates lockfile cleanly
- [x] `@xmldom/xmldom` resolves to `0.9.10` in `package-lock.json`
- [ ] CI green (unit tests, iOS build, Android build, version consistency check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)