### PR TITLE
fix(ci): use Node 24 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Ensure npm >= 11.5.1 (required for trusted publishing)
-        run: npm install -g npm@latest
 
       - name: Verify versions match release tag
         run: |


### PR DESCRIPTION
## Summary
- The 5.7.3 publish run failed at the `Ensure npm >= 11.5.1` step with `Cannot find module 'promise-retry'` during the npm self-upgrade on Node 22.
- Node 24 ships with npm 11.x natively, so the `npm install -g npm@latest` workaround is no longer required.

## Test plan
- [ ] Merge and re-run failed jobs of run 25324410022 to publish 5.7.3 to npm