### PR TITLE
fix(security): restore uuid override to fix open Dependabot alert

### DIFF
--- a/purchasely/example/package-lock.json
+++ b/purchasely/example/package-lock.json
@@ -938,6 +938,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -981,17 +995,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/xcode/node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/xmlbuilder": {

--- a/purchasely/example/package.json
+++ b/purchasely/example/package.json
@@ -23,7 +23,7 @@
   "overrides": {
     "@xmldom/xmldom": "^0.9.8",
     "plist": "^3.1.1",
-    "uuid": "7.0.3"
+    "uuid": "^11.1.1"
   },
   "cordova": {
     "plugins": {


### PR DESCRIPTION
## Summary
- Dependabot alert #22 (GHSA-w5hq-g745-h8pq / CVE-2026-41907, medium) was open on `uuid < 11.1.1` in `purchasely/example/package-lock.json`.
- PR #58 fixed it by overriding `uuid` to `^11.1.1`, but a follow-up commit in that same PR reverted the override back to the vulnerable `7.0.3`, out of an *unverified* concern (raised by an automated reviewer) that the `xcode` package — a transitive dep of `cordova-ios` — might break on uuid v11 due to removed sub-path imports (`require('uuid/v4')`).
- I verified that concern does not apply: `xcode` only ever calls `require('uuid').v4()` (no removed sub-path imports), which works correctly on uuid 11.1.1. Confirmed by requiring `xcode` with the new lockfile and calling `generateUuid()` directly — it returns a valid id.
- This PR restores the `uuid: "^11.1.1"` override, closing the alert.

## Validation
- `npm audit` in `purchasely/`, `purchasely/example/`: 0 vulnerabilities.
- All other Dependabot alerts in this repo are already `fixed`; #22 was the only open one.
- Manually verified `xcode`'s `generateUuid()` (which calls `uuid.v4()` internally) works against uuid 11.1.1.

## Test plan
- [ ] CI: unit tests, iOS build, Android build, version consistency check all pass
- [ ] Confirm Dependabot alert #22 auto-closes after merge