### PR TITLE
chore(ios): validate cordova-ios 8.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: purchasely
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         working-directory: purchasely
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install example dependencies
         working-directory: purchasely/example
-        run: npm install
+        run: npm ci
 
       # Restore CocoaPods downloaded pod sources BEFORE `cordova platform add`
       # so the implicit `pod install` triggered by `cordova prepare` reuses
@@ -71,14 +71,31 @@ jobs:
       - name: Setup iOS platform and plugins
         working-directory: purchasely/example
         run: |
-          cordova plugin remove @purchasely/cordova-plugin-purchasely || true
-          cordova platform remove ios || true
-          cordova platform add ios
-          cordova plugin add ../ --link
+          cordova plugin remove @purchasely/cordova-plugin-purchasely --nosave || true
+          cordova platform remove ios --nosave || true
+          cordova platform add ios@8.1.1 --nosave
+          cordova plugin add ../ --link --nosave
 
-      - name: Build iOS
+      - name: Build iOS release unsigned
         working-directory: purchasely/example
-        run: cordova build ios --emulator
+        run: |
+          xcodebuild build \
+            -workspace platforms/ios/App.xcworkspace \
+            -scheme App \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Archive iOS release unsigned
+        working-directory: purchasely/example
+        run: |
+          xcodebuild archive \
+            -workspace platforms/ios/App.xcworkspace \
+            -scheme App \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath build/App.xcarchive \
+            CODE_SIGNING_ALLOWED=NO
 
   build-android:
     name: Build Android
@@ -109,7 +126,7 @@ jobs:
 
       - name: Install example dependencies
         working-directory: purchasely/example
-        run: npm install
+        run: npm ci
 
       - name: Setup Android platform and plugins
         working-directory: purchasely/example

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
-# macOS
-.DS_Store
-
-# IDE artifacts (regenerated locally; not shared)
-.idea/caches/
-.idea/copilot.data.migration.*.xml
-.idea/markdown.xml
-.idea/inspectionProfiles/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
+# macOS
+.DS_Store
+
+# IDE artifacts (regenerated locally; not shared)
+.idea/caches/
+.idea/copilot.data.migration.*.xml
+.idea/markdown.xml
+.idea/inspectionProfiles/
+
+# git worktrees (local dev)
 .worktrees/

--- a/docs/superpowers/plans/2026-07-14-cordova-ios-8-1-1.md
+++ b/docs/superpowers/plans/2026-07-14-cordova-ios-8-1-1.md
@@ -10,7 +10,7 @@
 
 **Enhanced:** 2026-07-14  
 **Reviewed:** 2026-07-14  
-**Completed:** Pending
+**Completed:** 2026-07-14
 
 ---
 
@@ -19,9 +19,9 @@
 **Files:**
 - Modify: `purchasely/example/package.json`, `purchasely/example/package-lock.json`, `purchasely/example/ios.sh`
 
-- [ ] Declare `cordova-ios` as `8.1.1`, replace `ios@latest` installation with `ios@8.1.1`, and regenerate the lockfile with `npm ci` semantics.
-- [ ] Run the example's platform remove/add/build sequence and confirm the generated platform reports 8.1.1.
-- [ ] Commit with `chore(ios): pin cordova-ios 8.1.1`.
+- [x] Declare `cordova-ios` as `8.1.1`, replace `ios@latest` installation with `ios@8.1.1`, and regenerate the lockfile with `npm ci` semantics.
+- [x] Run the example's platform remove/add/build sequence and confirm the generated platform reports 8.1.1.
+- [x] Commit with `chore(ios): pin cordova-ios 8.1.1`.
 
 ### Task 2: Add reproducible archive CI and runtime checklist
 
@@ -29,6 +29,6 @@
 - Modify: `.github/workflows/ci.yml`
 - Create: `purchasely/example/IOS_8_1_1_TEST_MATRIX.md`
 
-- [ ] Use `npm ci`, install `ios@8.1.1`, build the generated release workspace, and run unsigned `xcodebuild archive` with `CODE_SIGNING_ALLOWED=NO`.
-- [ ] Document presentation, purchase, restore, close, JS callbacks, and background/foreground validation with explicit expected outcomes.
-- [ ] Validate workflow YAML and commit with `ci(ios): archive cordova-ios 8.1.1`.
+- [x] Use `npm ci`, install `ios@8.1.1`, build the generated release workspace, and run unsigned `xcodebuild archive` with `CODE_SIGNING_ALLOWED=NO`.
+- [x] Document presentation, purchase, restore, close, JS callbacks, and background/foreground validation with explicit expected outcomes.
+- [x] Validate workflow YAML and commit with `ci(ios): archive cordova-ios 8.1.1`.

--- a/docs/superpowers/plans/2026-07-14-cordova-ios-8-1-1.md
+++ b/docs/superpowers/plans/2026-07-14-cordova-ios-8-1-1.md
@@ -1,0 +1,34 @@
+# cordova-ios 8.1.1 Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Officially validate the Cordova v6 plugin on exactly cordova-ios 8.1.1.
+
+**Architecture:** The example manifest, lockfile workflow, scripts, and CI all install the same exact platform version. CI runs JavaScript tests, generated iOS release build, and unsigned archive while a documented manual matrix covers StoreKit-dependent behavior.
+
+**Tech Stack:** Cordova CLI, cordova-ios 8.1.1, npm, CocoaPods, Xcode, GitHub Actions.
+
+**Enhanced:** 2026-07-14  
+**Reviewed:** 2026-07-14  
+**Completed:** Pending
+
+---
+
+### Task 1: Pin the iOS platform used by the example
+
+**Files:**
+- Modify: `purchasely/example/package.json`, `purchasely/example/package-lock.json`, `purchasely/example/ios.sh`
+
+- [ ] Declare `cordova-ios` as `8.1.1`, replace `ios@latest` installation with `ios@8.1.1`, and regenerate the lockfile with `npm ci` semantics.
+- [ ] Run the example's platform remove/add/build sequence and confirm the generated platform reports 8.1.1.
+- [ ] Commit with `chore(ios): pin cordova-ios 8.1.1`.
+
+### Task 2: Add reproducible archive CI and runtime checklist
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Create: `purchasely/example/IOS_8_1_1_TEST_MATRIX.md`
+
+- [ ] Use `npm ci`, install `ios@8.1.1`, build the generated release workspace, and run unsigned `xcodebuild archive` with `CODE_SIGNING_ALLOWED=NO`.
+- [ ] Document presentation, purchase, restore, close, JS callbacks, and background/foreground validation with explicit expected outcomes.
+- [ ] Validate workflow YAML and commit with `ci(ios): archive cordova-ios 8.1.1`.

--- a/docs/superpowers/specs/2026-07-14-cordova-ios-8-1-1-design.md
+++ b/docs/superpowers/specs/2026-07-14-cordova-ios-8-1-1-design.md
@@ -1,0 +1,7 @@
+# cordova-ios 8.1.1 Validation Design
+
+**Scope:** Cordova SDK only; branch targets `feat/migration-v6`.
+
+The example and CI will use an exact `cordova-ios@8.1.1` installation rather than a range or `latest`. CI will use the lockfile, build an iOS release configuration, and produce an unsigned archive of the generated workspace. The existing JavaScript unit tests and Android validation remain intact.
+
+Presentation, close, purchase, restore, JavaScript callbacks, and background/foreground behavior require a configured StoreKit/runtime environment. They will be verified with an explicit manual matrix rather than being represented as build-only CI coverage. Existing CocoaPods linkage remains unchanged.

--- a/purchasely/example/IOS_8_1_1_TEST_MATRIX.md
+++ b/purchasely/example/IOS_8_1_1_TEST_MATRIX.md
@@ -1,0 +1,25 @@
+# cordova-ios 8.1.1 Manual Test Matrix
+
+Run this matrix on a physical iOS device or a StoreKit-configured simulator after:
+
+```bash
+cd purchasely/example
+./ios.sh
+cordova run ios --device
+```
+
+Use a Purchasely project with a presentation, a purchasable product, and a restorable
+purchase. Capture the app logs and the callback payloads for every row.
+
+| Scenario | Steps | Expected result |
+| --- | --- | --- |
+| Presentation | Trigger the sample presentation. | The configured presentation is displayed using the requested transition. |
+| Purchase | Select a product and complete the StoreKit purchase. | The StoreKit sheet completes, the purchase callback receives the Purchasely outcome, and the active entitlement is updated. |
+| Restore | Use the sample restore action with a previously purchased account. | The restore callback completes and the restored entitlement is available. |
+| Close | Dismiss the presentation through its close control and, separately, through the system back/dismiss gesture when enabled. | The close callback fires once per dismissal with the matching close reason; the final presentation outcome is delivered. |
+| JavaScript callbacks | Repeat presentation, purchase, restore, and close while logging every success, failure, presented, and close-requested callback. | Each callback is received on the JavaScript bridge with its expected payload and no duplicate terminal callback. |
+| Background and foreground | Show a presentation or StoreKit sheet, send the app to the background, then return it to the foreground. | The app remains responsive, the visible flow resumes or completes according to StoreKit, and no callback is lost or duplicated. |
+
+This matrix is runtime validation only. The CI job verifies deterministic installation,
+CocoaPods workspace build, and an unsigned archive; it cannot validate StoreKit or
+backend-configured presentation behavior.

--- a/purchasely/example/ios.sh
+++ b/purchasely/example/ios.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-cordova plugin remove @purchasely/cordova-plugin-purchasely
-cordova platform remove ios
-cordova platform add ios@latest
-cordova plugin add ../ --link
+npm ci
+cordova plugin remove @purchasely/cordova-plugin-purchasely --nosave
+cordova platform remove ios --nosave
+cordova platform add ios@8.1.1 --nosave
+cordova plugin add ../ --link --nosave
 
 if [[ $1 = true ]]
 then

--- a/purchasely/example/package-lock.json
+++ b/purchasely/example/package-lock.json
@@ -12,7 +12,7 @@
         "@purchasely/cordova-plugin-purchasely": "file:..",
         "@purchasely/cordova-plugin-purchasely-google": "file:../../purchasely-google",
         "cordova-android": "^15.0.0",
-        "cordova-ios": "^8.1.0",
+        "cordova-ios": "8.1.1",
         "cordova-plugin-purchasely": "file:..",
         "cordova-plugin-purchasely-google": "file:../../purchasely-google"
       }

--- a/purchasely/example/package.json
+++ b/purchasely/example/package.json
@@ -16,7 +16,7 @@
     "@purchasely/cordova-plugin-purchasely": "file:..",
     "@purchasely/cordova-plugin-purchasely-google": "file:../../purchasely-google",
     "cordova-android": "^15.0.0",
-    "cordova-ios": "^8.1.0",
+    "cordova-ios": "8.1.1",
     "cordova-plugin-purchasely": "file:..",
     "cordova-plugin-purchasely-google": "file:../../purchasely-google"
   },


### PR DESCRIPTION
## What changes
- Pins the sample and CI to cordova-ios 8.1.1.
- Adds an unsigned Release workspace build/archive and a manual StoreKit validation matrix.

## Why
CI previously installed a range or latest platform version, so 8.1.1 was not deterministically validated.

## Risks
No plugin runtime behavior or CocoaPods linkage changes; archive remains unsigned by design.

## How to test
- npm ci and npm test (82 tests)
- regenerate ios@8.1.1; run the generated workspace Release build and unsigned archive.