### PR TITLE
feat(v6): cross-platform parity audit remediation (wiring fixes, missing APIs)

### DIFF
--- a/MIGRATION-v6.md
+++ b/MIGRATION-v6.md
@@ -118,9 +118,9 @@ const presentation = await request.preload();   // screenId is authoritative
 const outcome = await request.display();
 ```
 
-> Android limitation, unchanged from the previous bridge: `onPresented` /
-> `onCloseRequested` do not fire on the `preload()` → `display()` re-display path (iOS
-> fires them on both paths). The final outcome always resolves on both platforms.
+> `onPresented` / `onCloseRequested` fire on the `preload()` → `display()` re-display
+> path on both platforms (matching the direct `display()` path). The final outcome always
+> resolves on both platforms.
 
 ### Display transitions
 
@@ -174,9 +174,8 @@ const request = Purchasely.presentation.placement('ONBOARDING')
 await request.display();
 ```
 
-> `onPresented` / `onCloseRequested` fire for the direct `display()` path on both
-> platforms; on Android they do not fire for the `preload()` → `display()` re-display path
-> (iOS fires them on both paths).
+> `onPresented` / `onCloseRequested` fire on both the direct `display()` path and the
+> `preload()` → `display()` re-display path, on both platforms.
 
 ### Close / back
 

--- a/MIGRATION-v6.md
+++ b/MIGRATION-v6.md
@@ -281,7 +281,44 @@ callback) exposes:
 ## 8. New exported constants
 
 `InterceptResult`, `PresentationType`, `CloseReason`, `TransitionType`, `DimensionType`,
-`Store`, `StorekitVersion`, `PresentationAction`.
+`Store`, `StorekitVersion`, `PresentationAction`, `BillingPlanType`.
+
+## 9. Apple commitment info (iOS 26.4+, Apple only)
+
+Apple's "monthly subscription with 12-month commitment" is now surfaced through the bridge.
+These fields are **iOS-only** — they are absent on Android and on plans/subscriptions without
+a commitment, so read them defensively.
+
+- **`Purchasely.BillingPlanType`** — `{ unspecified: 0, upFront: 1, monthly: 2 }`. Pass it as
+  the new 4th argument of `setDynamicOffering(reference, planVendorId, offerVendorId,
+  billingPlanType, success, error)` (defaults to `unspecified` when omitted).
+
+- **`plan.commitmentInfo`** — an array present on plans returned by `allProducts()` /
+  `planWithIdentifier()`, on a presentation outcome's `plan`, and on the
+  `interceptAction('purchase')` payload's `parameters.plan`. Each entry:
+
+  ```js
+  {
+    billingPlanType, // Number — see Purchasely.BillingPlanType
+    billingPrice,    // Number — per-cycle price
+    billingPeriod,   // String — ISO 8601 duration, e.g. "P1M"
+    totalPrice,      // Number — total over the full commitment
+    totalPeriod,     // String — ISO 8601 duration, e.g. "P1Y"
+    totalDuration    // Number — number of billing cycles (e.g. 12)
+  }
+  ```
+
+- **`subscription.commitmentProgress`** — present on subscriptions returned by
+  `userSubscriptions()` / `userSubscriptionsHistory()`:
+
+  ```js
+  {
+    billingPeriodNumber,   // Number — current billing period (1-based)
+    totalBillingPeriods,   // Number — total periods in the commitment
+    commitmentExpiresDate, // String — ISO 8601 date
+    commitmentPrice        // Number — price for this period
+  }
+  ```
 
 ---
 

--- a/MIGRATION-v6.md
+++ b/MIGRATION-v6.md
@@ -3,8 +3,8 @@
 `@purchasely/cordova-plugin-purchasely@6.0.0-rc.3` wraps the Purchasely **6.0** native
 SDKs (iOS `Purchasely 6.0.0-rc.3`, Android `io.purchasely:core 6.0.0-rc.3`). This guide
 lists every change to the JavaScript API. Most of the SDK is source-compatible; the
-breaking surfaces are **SDK start**, **presentation display mode**, and the **action
-interceptor result**.
+breaking surfaces are **SDK start**, the **presentation API** (now a builder, parity
+with the React Native/Flutter SDKs), and the **action interceptor result**.
 
 > The 6.0 line is a release candidate. It is published to npm under the `next` dist-tag:
 > `cordova plugin add @purchasely/cordova-plugin-purchasely@next`.
@@ -82,23 +82,59 @@ Purchasely.synchronize(
 );
 ```
 
-## 4. Presentation display mode & transitions
+## 4. Presentation API is now the v6 builder (breaking)
 
-The `isFullscreen` boolean on the `present*` methods is replaced by a **display mode**.
-Pass either a `Purchasely.TransitionType` string or a full **transition object** (for
-drawer/popin sizing). Legacy booleans still work (`true` → `fullScreen`, `false` → `modal`).
+The imperative presentation surface (`presentPresentationForPlacement`,
+`presentPresentationWithIdentifier`, `presentPresentationForDefault`, `fetchPresentation`,
+`fetchPresentationForPlacement`, `fetchPresentationForDefault`, `presentPresentation`,
+`backPresentation`) is **REMOVED**, not deprecated — replaced by a chainable, promise-based
+builder that matches the React Native and Flutter SDKs. It wraps the exact same native
+actions those methods used; only the JavaScript surface changed.
 
 ```js
-// Simple: a display-mode string
-Purchasely.presentPresentationForPlacement('ONBOARDING', null, Purchasely.TransitionType.fullScreen, ok, err);
+// Present a placement full-screen (was presentPresentationForPlacement)
+const outcome = await Purchasely.presentation.placement('ONBOARDING').build().display();
 
-// Rich: a transition object (drawer/popin sizing, dismissible, background color)
-Purchasely.presentPresentationForPlacement('ONBOARDING', null, {
+// Present a specific screen (was presentPresentationWithIdentifier)
+await Purchasely.presentation.screen('SCREEN_ID').build().display();
+
+// Present the default (audience-targeted) presentation (was presentPresentationForDefault)
+await Purchasely.presentation.defaultSource().build().display(); // or .default(), iOS-style alias
+
+// Preselect a product/plan content id (was the contentId parameter)
+await Purchasely.presentation.placement('ONBOARDING').contentId('my_content_id').build().display();
+```
+
+`display()` resolves at **dismiss** with a 5-field outcome:
+`{ presentation, purchaseResult, plan, closeReason, error }` (`presentation.screenId` is
+the authoritative identifier — see below).
+
+### Preloading (was `fetchPresentation*` + `presentPresentation`)
+
+```js
+const request = Purchasely.presentation.placement('ONBOARDING').build();
+const presentation = await request.preload();   // screenId is authoritative
+// ...later, re-display the exact screen that was preloaded:
+const outcome = await request.display();
+```
+
+> Android limitation, unchanged from the previous bridge: `onPresented` /
+> `onCloseRequested` do not fire on the `preload()` → `display()` re-display path (iOS
+> fires them on both paths). The final outcome always resolves on both platforms.
+
+### Display transitions
+
+`display(transition?)` takes the same transition object as before — a
+`Purchasely.TransitionType` string, a legacy boolean (`true` → `fullScreen`, `false` →
+`modal`), or a full transition object for drawer/popin sizing:
+
+```js
+await Purchasely.presentation.placement('ONBOARDING').build().display({
   type: Purchasely.TransitionType.drawer,
   dismissible: true,
   height: { type: Purchasely.DimensionType.percentage, value: 0.8 }, // 0.0–1.0
   backgroundColor: '#000000'
-}, ok, err);
+});
 ```
 
 `TransitionType`: `fullScreen`, `modal`, `drawer`, `popin`, `push`, `inlinePaywall`.
@@ -108,43 +144,57 @@ Purchasely.presentPresentationForPlacement('ONBOARDING', null, {
 > `backgroundColor`) is applied to drawer/popin — pixel sizing and popin `width` are not
 > exposed to the bridge by the native iOS SDK. **Android** honors the full set.
 
-### Presentation lifecycle callbacks
+### Lifecycle callbacks
 
-The `present*` methods accept an optional final `callbacks` object to observe the
-presentation lifecycle. The `success` callback still receives the final dismiss outcome.
-
-```js
-Purchasely.presentPresentationForPlacement('ONBOARDING', null, Purchasely.TransitionType.fullScreen,
-  (outcome) => console.log('dismissed', outcome.purchaseResult, outcome.closeReason),
-  (err) => console.error(err),
-  {
-    onPresented: (presentation, error) => console.log('presented', presentation && presentation.screenId),
-    onCloseRequested: () => console.log('user requested close'),
-  }
-);
-```
-
-> `onPresented` / `onCloseRequested` fire for the direct `present*` methods on both
-> platforms; on Android they do not fire for the `fetchPresentation` → `presentPresentation`
-> re-display path (iOS covers both).
-
-### Default (audience-targeted) presentation
-
-Present or fetch the default presentation — no placement or presentation id:
+`onPresented` / `onCloseRequested` / `onDismissed` are chained on the builder, before
+`.build()`:
 
 ```js
-Purchasely.presentPresentationForDefault(null /* contentId */, Purchasely.TransitionType.fullScreen, ok, err);
-Purchasely.fetchPresentationForDefault(null /* contentId */, onLoaded, err);
+const request = Purchasely.presentation.placement('ONBOARDING')
+  .onPresented((presentation, error) => console.log('presented', presentation && presentation.screenId))
+  .onCloseRequested(() => console.log('user requested close'))
+  .onDismissed((outcome) => console.log('dismissed', outcome.purchaseResult, outcome.closeReason))
+  .build();
+
+await request.display();
 ```
 
-### Removed presentation methods
+> `onPresented` / `onCloseRequested` fire for the direct `display()` path on both
+> platforms; on Android they do not fire for the `preload()` → `display()` re-display path
+> (iOS fires them on both paths).
+
+### Close / back
+
+```js
+request.close(); // closeAllScreens() under the hood — closes every displayed screen
+request.back();  // was the standalone backPresentation()
+```
+
+### screenId is authoritative
+
+Every presentation object returned by `preload()`, or carried in an outcome's
+`presentation` field, exposes `screenId` as the stable public identifier (the JS bridge
+tolerates a raw `id` fallback, `screenId ?? id`, for defensiveness). Any native re-display
+handle used internally to make `preload()` → `display()` work (e.g. Android's synthetic
+fetch handle) is a private implementation detail of the request and is never part of the
+returned presentation object.
+
+### Migration table
 
 | Removed | Replacement |
 |---|---|
+| `fetchPresentation(id, contentId, ok, err)` | `Purchasely.presentation.screen(id).contentId(contentId).build().preload()` |
+| `fetchPresentationForPlacement(id, contentId, ok, err)` | `Purchasely.presentation.placement(id).contentId(contentId).build().preload()` |
+| `fetchPresentationForDefault(contentId, ok, err)` | `Purchasely.presentation.defaultSource().contentId(contentId).build().preload()` |
+| `presentPresentationWithIdentifier(id, contentId, mode, ok, err, cb)` | `Purchasely.presentation.screen(id).contentId(contentId).onPresented(...).onCloseRequested(...).build().display(mode)` |
+| `presentPresentationForPlacement(id, contentId, mode, ok, err, cb)` | `Purchasely.presentation.placement(id).contentId(contentId)...build().display(mode)` |
+| `presentPresentationForDefault(contentId, mode, ok, err, cb)` | `Purchasely.presentation.defaultSource().contentId(contentId)...build().display(mode)` |
+| `presentPresentation(presentation, mode, bgColor, ok, err, cb)` | `request.preload()` then `request.display(mode)` on that same request |
+| `backPresentation()` | `request.back()` |
 | `presentSubscriptions()` | No native screen in 6.0. Build your own from `userSubscriptions()` / `userSubscriptionsHistory()`. |
-| `presentProductWithIdentifier()` | Use placement/screen-based presentation (`presentPresentationForPlacement` / `presentPresentationWithIdentifier`). |
-| `presentPlanWithIdentifier()` | Same as above. |
-| `showPresentation()` / `hidePresentation()` | No hide/show primitive in 6.0. Use `closePresentation()`; `backPresentation()` was added to navigate back. |
+| `presentProductWithIdentifier()` | `Purchasely.presentation.screen(id).contentId(contentId).build().display()` |
+| `presentPlanWithIdentifier()` | `Purchasely.presentation.screen(id).build().display()` |
+| `showPresentation()` / `hidePresentation()` | `request.display()` / `request.close()` |
 
 ## 5. Action interceptor
 

--- a/MIGRATION-v6.md
+++ b/MIGRATION-v6.md
@@ -144,6 +144,21 @@ await Purchasely.presentation.placement('ONBOARDING').build().display({
 > `backgroundColor`) is applied to drawer/popin — pixel sizing and popin `width` are not
 > exposed to the bridge by the native iOS SDK. **Android** honors the full set.
 
+### Presentation modifiers
+
+`.backgroundColor(hex)` sets the loading/background color:
+
+```js
+await Purchasely.presentation.placement('ONBOARDING').backgroundColor('#101010').build().display();
+```
+
+> It is the only style modifier wired through the Cordova bridge, and it takes effect on
+> **iOS** (passed to `presentPresentation`'s native background argument on the
+> `preload()` → `display()` path, and via the transition on the direct path). On **Android**
+> a background color only applies through a drawer/popin transition (native limitation). The
+> RN/Flutter builder's `progressColor`, `displayCloseButton` and `displayBackButton` are
+> **not** available on Cordova — no native present action accepts them.
+
 ### Lifecycle callbacks
 
 `onPresented` / `onCloseRequested` / `onDismissed` are chained on the builder, before

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ cordova plugin add @purchasely/cordova-plugin-purchasely-google
 More details in our [documentation](https://docs.purchasely.com/quick-start/sdk-implementation).
 
 > **Upgrading from 5.x?** See [MIGRATION-v6.md](MIGRATION-v6.md) — `start()` now takes an
-> options object, `RunningMode` defaults to `observer`, and a few methods were renamed.
+> options object, `RunningMode` defaults to `observer`, the presentation API is now a
+> builder (`Purchasely.presentation`), and a few methods were renamed.
 
 ```js
 Purchasely.start(
@@ -40,23 +41,24 @@ Purchasely.start(
     }
 );
 
-// display a paywall from a placement
-Purchasely.presentPresentationForPlacement(
-    'placementId',
-    'my_content_id', // may be null
-    Purchasely.TransitionType.fullScreen, // display mode
-    (callback) => {
-        console.log(callback);
-        if(callback.result == Purchasely.PurchaseResult.CANCELLED) {
-            console.log("User cancelled purchased");
+// display a paywall from a placement — Purchasely.presentation is the v6 builder:
+// pick a source (.placement/.screen/.defaultSource), .build(), then .display(transition?).
+// display() resolves at dismiss with a 5-field outcome.
+Purchasely.presentation
+    .placement('placementId')
+    .contentId('my_content_id') // optional, may be omitted
+    .build()
+    .display(Purchasely.TransitionType.fullScreen) // display mode
+    .then((outcome) => {
+        console.log(outcome);
+        if (outcome.error) {
+            console.log("Error with purchase : " + outcome.error);
+        } else if (outcome.purchaseResult === 'purchased' || outcome.purchaseResult === 'restored') {
+            console.log("User purchased " + outcome.plan.name);
         } else {
-            console.log("User purchased " + callback.plan.name);
+            console.log("User cancelled purchased");
         }
-    },
-    (error) => {
-        console.log("Error with purchase : " + error);
-    }
-);
+    });
 ```
 
 ## 🏁 Documentation

--- a/purchasely/README.md
+++ b/purchasely/README.md
@@ -47,6 +47,14 @@ Purchasely.presentPresentationWithIdentifier(
 );
 ```
 
+## Limitations
+
+- **No inline/embedded paywall view.** iOS, Android, Flutter and React Native all support
+  embedding a paywall directly inside a screen (`PLYPresentationView` / `buildView` /
+  `getFragment`). This is not available on Cordova: the plugin only supports modal/fullscreen
+  presentation via `presentPresentation*`. Embedding a native view inside the WebView isn't
+  supported by this bridge architecture; this is an accepted platform limitation, not a bug.
+
 ## 🏁 Documentation
 
 A complete documentation is available on our website [https://docs.purchasely.com](https://docs.purchasely.com/quick-start/sdk-installation/cordova)

--- a/purchasely/__tests__/Purchasely.test.js
+++ b/purchasely/__tests__/Purchasely.test.js
@@ -672,7 +672,8 @@ describe('Purchasely', () => {
 
         const outcome = await outcomePromise;
 
-        expect(onPresented).toHaveBeenCalledWith({ screenId: 's' }, null);
+        // The 'presented' envelope's presentation is screenId-normalized like everywhere else.
+        expect(onPresented).toHaveBeenCalledWith(fullPresentation({ screenId: 's' }), null);
         expect(onCloseRequested).toHaveBeenCalledTimes(1);
         expect(onDismissed).toHaveBeenCalledWith(outcome);
         expect(outcome).toEqual({
@@ -785,6 +786,53 @@ describe('Purchasely', () => {
         fetchCall[1]('Screen not found');
 
         await expect(preloadPromise).rejects.toEqual({ message: 'Screen not found' });
+      });
+
+      // Android asymmetry regression (v6 audit): onPresented/onCloseRequested previously only
+      // fired on the direct present* path. The re-display action (presentPresentation, reached
+      // via preload() -> display()) must route the very same keep-alive envelopes to the
+      // builder's callbacks, resolving the display() Promise only once the final (non-kept)
+      // outcome envelope arrives -- envelopes strictly before resolution.
+      it('routes presented/closeRequested envelopes on the preload() -> display() path too, resolving only at the final outcome', async () => {
+        const onPresented = jest.fn();
+        const onCloseRequested = jest.fn();
+        const order = [];
+        onPresented.mockImplementation(() => order.push('presented'));
+        onCloseRequested.mockImplementation(() => order.push('closeRequested'));
+
+        const request = Purchasely.presentation
+          .screen('screen1')
+          .onPresented(onPresented)
+          .onCloseRequested(onCloseRequested)
+          .build();
+
+        const preloadPromise = request.preload();
+        const rawFetched = { screenId: 'screen1', fetchId: 'ply_fetch_789' };
+        execCallFor('fetchPresentation')[0](rawFetched);
+        await preloadPromise;
+
+        const outcomePromise = request.display();
+        const displayCall = execCallFor('presentPresentation');
+        const dispatch = displayCall[0];
+
+        dispatch({ event: 'presented', presentation: { screenId: 'screen1' } });
+        dispatch({ event: 'closeRequested' });
+        expect(order).toEqual(['presented', 'closeRequested']);
+        // Neither envelope resolves the Promise -- only the final outcome does.
+        let settled = false;
+        outcomePromise.then(() => { settled = true; });
+        await Promise.resolve();
+        expect(settled).toBe(false);
+        order.push('outcome-dispatched');
+
+        dispatch({ closeReason: 'button', presentation: { screenId: 'screen1' } });
+        const outcome = await outcomePromise;
+
+        // Envelopes fired strictly before the Promise resolved.
+        expect(order).toEqual(['presented', 'closeRequested', 'outcome-dispatched']);
+        expect(onPresented).toHaveBeenCalledWith(fullPresentation({ screenId: 'screen1' }), null);
+        expect(onCloseRequested).toHaveBeenCalledTimes(1);
+        expect(outcome.closeReason).toBe('button');
       });
     });
 

--- a/purchasely/__tests__/Purchasely.test.js
+++ b/purchasely/__tests__/Purchasely.test.js
@@ -610,6 +610,46 @@ describe('Purchasely', () => {
       });
     });
 
+    describe('backgroundColor', () => {
+      it('merges into the transition object on the direct present* path (no forced type)', async () => {
+        const outcomePromise = Purchasely.presentation
+          .placement('placement1')
+          .backgroundColor('#101010')
+          .build()
+          .display();
+
+        const call = execCallFor('presentPresentationForPlacement');
+        // No display-mode given: only backgroundColor, no `type`, so the backend
+        // transition default is still honored (CDV-W-12).
+        expect(call[4][2]).toEqual({ backgroundColor: '#101010' });
+        call[0]({ closeReason: 'button' });
+        await outcomePromise;
+      });
+
+      it('is forwarded as presentPresentation\'s native backgroundColor arg on the re-display path', async () => {
+        const request = Purchasely.presentation.screen('screen1').backgroundColor('#202020').build();
+
+        const preloadPromise = request.preload();
+        const rawFetched = { screenId: 'screen1', fetchId: 'ply_fetch_789' };
+        execCallFor('fetchPresentation')[0](rawFetched);
+        await preloadPromise;
+
+        const outcomePromise = request.display();
+        const displayCall = execCallFor('presentPresentation');
+        expect(displayCall[4][0]).toBe(rawFetched);
+        expect(displayCall[4][2]).toBe('#202020');
+        displayCall[0]({ closeReason: 'programmatic' });
+        await outcomePromise;
+      });
+
+      it('does not expose progressColor / displayCloseButton / displayBackButton (no Cordova native support)', () => {
+        const builder = Purchasely.presentation.placement('placement1');
+        expect(builder.progressColor).toBeUndefined();
+        expect(builder.displayCloseButton).toBeUndefined();
+        expect(builder.displayBackButton).toBeUndefined();
+      });
+    });
+
     describe('lifecycle callbacks', () => {
       it('routes presented/closeRequested envelopes to the builder callbacks, and the final outcome to onDismissed + the resolved promise', async () => {
         const onPresented = jest.fn();
@@ -695,9 +735,11 @@ describe('Purchasely', () => {
         fetchCall[0](rawFetched);
 
         const presentation = await preloadPromise;
-        expect(presentation).toEqual(fullPresentation({ screenId: 'onboarding-screen', placementId: 'placement1' }));
-        // The native re-display handle (fetchId) is never exposed on the returned object.
+        // The screenId-normalized data is present (methods are added on top, below).
+        expect(presentation).toMatchObject(fullPresentation({ screenId: 'onboarding-screen', placementId: 'placement1' }));
+        // The native re-display handle is never exposed on the returned object.
         expect(presentation.fetchId).toBeUndefined();
+        expect(presentation.id).toBeUndefined();
 
         const outcomePromise = request.display();
         const displayCall = execCallFor('presentPresentation');
@@ -707,6 +749,32 @@ describe('Purchasely', () => {
 
         const outcome = await outcomePromise;
         expect(outcome.closeReason).toBe('programmatic');
+      });
+
+      it('the loaded presentation exposes display()/close()/back() delegating to its request', async () => {
+        const request = Purchasely.presentation.screen('screen1').build();
+
+        const preloadPromise = request.preload();
+        const rawFetched = { screenId: 'screen1', fetchId: 'ply_fetch_456' };
+        execCallFor('fetchPresentation')[0](rawFetched);
+
+        const loaded = await preloadPromise;
+        expect(typeof loaded.display).toBe('function');
+        expect(typeof loaded.close).toBe('function');
+        expect(typeof loaded.back).toBe('function');
+
+        // display() on the loaded object re-displays via the same request/handle.
+        const outcomePromise = loaded.display();
+        const displayCall = execCallFor('presentPresentation');
+        expect(displayCall[4][0]).toBe(rawFetched);
+        displayCall[0]({ closeReason: 'programmatic' });
+        await outcomePromise;
+
+        // close() / back() delegate to the request's native actions.
+        loaded.close();
+        expect(execCallFor('closeAllScreens')).toBeDefined();
+        loaded.back();
+        expect(execCallFor('backPresentation')).toBeDefined();
       });
 
       it('rejects preload() on native failure', async () => {

--- a/purchasely/__tests__/Purchasely.test.js
+++ b/purchasely/__tests__/Purchasely.test.js
@@ -228,6 +228,46 @@ describe('Purchasely', () => {
         ]
       );
     });
+
+    it('should fall back to the literal default sdkVersion when plugin_list metadata is missing', () => {
+      const metadata = global.cordova.define.moduleMap['cordova/plugin_list'].exports.metadata;
+      const original = metadata['cordova-plugin-purchasely'];
+      delete metadata['cordova-plugin-purchasely'];
+
+      try {
+        Purchasely.start({ apiKey: 'API_KEY' }, jest.fn(), jest.fn());
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'start',
+          [{ apiKey: 'API_KEY', sdkVersion: '6.0.0-rc.3' }]
+        );
+      } finally {
+        metadata['cordova-plugin-purchasely'] = original;
+      }
+    });
+
+    it('should treat a v5-style positional call as broken (no longer supported)', () => {
+      // Purchasely 6.0: `start` takes a single options object. A v5-style positional
+      // call (apiKey, stores, storeKit1, ...) is NOT supported: `options` becomes the
+      // raw apiKey string (sdkVersion silently fails to attach to a string primitive),
+      // and `success`/`error` are mis-bound to the 2nd/3rd positional args instead of
+      // the real callbacks. This documents the breaking change from MIGRATION-v6.md.
+      const legacyStores = ['Google'];
+      const legacyStoreKit1 = false;
+
+      Purchasely.start('API_KEY', legacyStores, legacyStoreKit1, null, 0, 'full', jest.fn(), jest.fn());
+
+      expect(mockExec).toHaveBeenCalledWith(
+        legacyStores,
+        legacyStoreKit1,
+        'Purchasely',
+        'start',
+        ['API_KEY']
+      );
+    });
   });
 
   describe('addEventsListener', () => {
@@ -472,6 +512,21 @@ describe('Purchasely', () => {
         'Purchasely',
         'presentPresentationForPlacement',
         ['placement1', 'content1', { type: 'modal' }]
+      );
+    });
+
+    it('should default to fullScreen when no displayMode is provided (normalizeTransition default)', () => {
+      const success = jest.fn();
+      const error = jest.fn();
+
+      Purchasely.presentPresentationForPlacement('placement1', 'content1', undefined, success, error);
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.any(Function),
+        error,
+        'Purchasely',
+        'presentPresentationForPlacement',
+        ['placement1', 'content1', { type: 'fullScreen' }]
       );
     });
   });
@@ -1156,6 +1211,40 @@ describe('Purchasely', () => {
         'setDebugMode',
         [true]
       );
+    });
+  });
+
+  // Purchasely 6.0: these v5 APIs were deliberately removed (see MIGRATION-v6.md).
+  // Asserting their absence guards against accidental resurrection/typos reintroducing
+  // a v5-shaped surface alongside the v6 replacements.
+  describe('Removed v5 APIs (should not exist in v6)', () => {
+    it('removes the presentation methods with no v6 native screen equivalent', () => {
+      expect(Purchasely.presentSubscriptions).toBeUndefined();
+      expect(Purchasely.presentProductWithIdentifier).toBeUndefined();
+      expect(Purchasely.presentPlanWithIdentifier).toBeUndefined();
+      expect(Purchasely.showPresentation).toBeUndefined();
+      expect(Purchasely.hidePresentation).toBeUndefined();
+    });
+
+    it('removes the single global action interceptor in favor of interceptAction(kind, handler)', () => {
+      expect(Purchasely.setPaywallActionInterceptor).toBeUndefined();
+      expect(Purchasely.onProcessAction).toBeUndefined();
+      expect(Purchasely.PaywallAction).toBeUndefined();
+    });
+
+    it('removes the renamed deeplink methods', () => {
+      expect(Purchasely.readyToOpenDeeplink).toBeUndefined();
+      expect(Purchasely.isDeeplinkHandled).toBeUndefined();
+    });
+
+    it('removes the renamed default dismiss handler', () => {
+      expect(Purchasely.setDefaultPresentationResultHandler).toBeUndefined();
+    });
+
+    it('removes the RunningMode values dropped by native 6.0', () => {
+      expect(Purchasely.RunningMode.paywallObserver).toBeUndefined();
+      expect(Purchasely.RunningMode.transactionOnly).toBeUndefined();
+      expect(Object.keys(Purchasely.RunningMode).sort()).toEqual(['full', 'observer']);
     });
   });
 });

--- a/purchasely/__tests__/Purchasely.test.js
+++ b/purchasely/__tests__/Purchasely.test.js
@@ -502,119 +502,270 @@ describe('Purchasely', () => {
     });
   });
 
-  describe('presentPresentationWithIdentifier', () => {
-    it('should pass a display-mode string as a transition object', () => {
-      const success = jest.fn();
-      const error = jest.fn();
+  // Purchasely 6.0: the v5 presentation surface (fetchPresentation*, presentPresentation*,
+  // backPresentation) is REMOVED, replaced by the promise-based v6 builder
+  // (Purchasely.presentation), which re-wraps the very same native exec actions.
+  describe('presentation builder (v6)', () => {
+    // Grabs the exec() call for a given native action, most recent first.
+    const execCallFor = (action) => {
+      const calls = mockExec.mock.calls.filter((c) => c[3] === action);
+      return calls[calls.length - 1];
+    };
 
-      Purchasely.presentPresentationWithIdentifier('presentation1', 'content1', Purchasely.TransitionType.drawer, success, error);
-
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.any(Function),
-        error,
-        'Purchasely',
-        'presentPresentationWithIdentifier',
-        ['presentation1', 'content1', { type: 'drawer' }]
-      );
+    // normalizePresentation always returns this exact whitelist of documented fields
+    // (defaulting the ones the raw payload didn't carry to null); tests merge in the
+    // fields they care about rather than repeating the full shape each time.
+    const fullPresentation = (overrides) => ({
+      screenId: null,
+      placementId: null,
+      contentId: null,
+      audienceId: null,
+      abTestId: null,
+      abTestVariantId: null,
+      campaignId: null,
+      flowId: null,
+      language: null,
+      type: null,
+      plans: null,
+      metadata: null,
+      height: null,
+      ...overrides,
     });
 
-    it('should normalize a legacy isFullscreen=true to fullScreen', () => {
-      const success = jest.fn();
-      const error = jest.fn();
+    describe('sources', () => {
+      it('.placement(id).build().display() calls presentPresentationForPlacement', async () => {
+        const outcomePromise = Purchasely.presentation.placement('placement1').build().display();
 
-      Purchasely.presentPresentationWithIdentifier('presentation1', 'content1', true, success, error);
+        const call = execCallFor('presentPresentationForPlacement');
+        expect(call[4]).toEqual(['placement1', null, undefined]);
+        call[0]({ purchaseResult: null, plan: null, closeReason: 'button', error: null, presentation: null });
 
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.any(Function),
-        error,
-        'Purchasely',
-        'presentPresentationWithIdentifier',
-        ['presentation1', 'content1', { type: 'fullScreen' }]
-      );
+        const outcome = await outcomePromise;
+        expect(outcome.closeReason).toBe('button');
+      });
+
+      it('.screen(id).build().display() calls presentPresentationWithIdentifier', async () => {
+        const outcomePromise = Purchasely.presentation.screen('screen1').build().display();
+
+        const call = execCallFor('presentPresentationWithIdentifier');
+        expect(call[4]).toEqual(['screen1', null, undefined]);
+        call[0]({ purchaseResult: null, plan: null, closeReason: 'programmatic', error: null, presentation: null });
+
+        await outcomePromise;
+      });
+
+      it('.defaultSource().build().display() calls presentPresentationForDefault', async () => {
+        const outcomePromise = Purchasely.presentation.defaultSource().build().display();
+
+        const call = execCallFor('presentPresentationForDefault');
+        expect(call[4]).toEqual([null, undefined]);
+        call[0]({ purchaseResult: null, plan: null, closeReason: 'button', error: null, presentation: null });
+
+        await outcomePromise;
+      });
+
+      it('.default() is an alias of .defaultSource()', async () => {
+        const outcomePromise = Purchasely.presentation.default().build().display();
+
+        const call = execCallFor('presentPresentationForDefault');
+        expect(call[4]).toEqual([null, undefined]);
+        call[0]({ purchaseResult: null, plan: null, closeReason: 'button', error: null, presentation: null });
+
+        await outcomePromise;
+      });
     });
 
-    it('should pass a full transition object (dimensions/dismissible) through unchanged', () => {
-      const success = jest.fn();
-      const error = jest.fn();
-      const transition = { type: 'drawer', dismissible: false, height: { type: 'percentage', value: 0.8 } };
+    describe('contentId', () => {
+      it('is forwarded to the matching present* action', async () => {
+        const outcomePromise = Purchasely.presentation.placement('placement1').contentId('content1').build().display();
 
-      Purchasely.presentPresentationWithIdentifier('presentation1', null, transition, success, error);
+        const call = execCallFor('presentPresentationForPlacement');
+        expect(call[4]).toEqual(['placement1', 'content1', undefined]);
+        call[0]({ closeReason: 'button' });
 
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.any(Function),
-        error,
-        'Purchasely',
-        'presentPresentationWithIdentifier',
-        ['presentation1', null, transition]
-      );
-    });
-  });
-
-  describe('presentPresentationForPlacement', () => {
-    it('should normalize a legacy isFullscreen=false to modal', () => {
-      const success = jest.fn();
-      const error = jest.fn();
-
-      Purchasely.presentPresentationForPlacement('placement1', 'content1', false, success, error);
-
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.any(Function),
-        error,
-        'Purchasely',
-        'presentPresentationForPlacement',
-        ['placement1', 'content1', { type: 'modal' }]
-      );
+        await outcomePromise;
+      });
     });
 
-    it('should send no transition when no displayMode is provided, so the backend default is honored (CDV-W-12)', () => {
-      const success = jest.fn();
-      const error = jest.fn();
+    describe('display(transition)', () => {
+      it('normalizes a display-mode string to a transition object', async () => {
+        const outcomePromise = Purchasely.presentation.screen('screen1').build().display(Purchasely.TransitionType.drawer);
 
-      Purchasely.presentPresentationForPlacement('placement1', 'content1', undefined, success, error);
+        const call = execCallFor('presentPresentationWithIdentifier');
+        expect(call[4][2]).toEqual({ type: 'drawer' });
+        call[0]({ closeReason: 'button' });
 
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.any(Function),
-        error,
-        'Purchasely',
-        'presentPresentationForPlacement',
-        ['placement1', 'content1', undefined]
-      );
+        await outcomePromise;
+      });
+
+      it('passes a full transition object through unchanged', async () => {
+        const transition = { type: 'drawer', dismissible: false, height: { type: 'percentage', value: 0.8 } };
+        const outcomePromise = Purchasely.presentation.placement('placement1').build().display(transition);
+
+        const call = execCallFor('presentPresentationForPlacement');
+        expect(call[4][2]).toEqual(transition);
+        call[0]({ closeReason: 'button' });
+
+        await outcomePromise;
+      });
     });
-  });
 
-  describe('presentPresentationForDefault', () => {
-    it('should present the default presentation with a transition object', () => {
-      const success = jest.fn();
-      const error = jest.fn();
+    describe('lifecycle callbacks', () => {
+      it('routes presented/closeRequested envelopes to the builder callbacks, and the final outcome to onDismissed + the resolved promise', async () => {
+        const onPresented = jest.fn();
+        const onCloseRequested = jest.fn();
+        const onDismissed = jest.fn();
 
-      Purchasely.presentPresentationForDefault('content1', Purchasely.TransitionType.fullScreen, success, error);
+        const outcomePromise = Purchasely.presentation
+          .placement('placement1')
+          .onPresented(onPresented)
+          .onCloseRequested(onCloseRequested)
+          .onDismissed(onDismissed)
+          .build()
+          .display();
 
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.any(Function),
-        error,
-        'Purchasely',
-        'presentPresentationForDefault',
-        ['content1', { type: 'fullScreen' }]
-      );
+        const call = execCallFor('presentPresentationForPlacement');
+        const dispatch = call[0];
+        dispatch({ event: 'presented', presentation: { screenId: 's' } });
+        dispatch({ event: 'closeRequested' });
+        dispatch({ purchaseResult: 'cancelled', plan: null, closeReason: 'button', error: null, presentation: { screenId: 's' } });
+
+        const outcome = await outcomePromise;
+
+        expect(onPresented).toHaveBeenCalledWith({ screenId: 's' }, null);
+        expect(onCloseRequested).toHaveBeenCalledTimes(1);
+        expect(onDismissed).toHaveBeenCalledWith(outcome);
+        expect(outcome).toEqual({
+          presentation: fullPresentation({ screenId: 's' }),
+          purchaseResult: 'cancelled',
+          plan: null,
+          closeReason: 'button',
+          error: null,
+        });
+      });
     });
-  });
 
-  describe('presentation lifecycle callbacks', () => {
-    it('routes presented/closeRequested envelopes to callbacks and the final outcome to success', () => {
-      const success = jest.fn();
-      const onPresented = jest.fn();
-      const onCloseRequested = jest.fn();
+    describe('outcome normalization (5 fields)', () => {
+      it('exposes exactly presentation/purchaseResult/plan/closeReason/error, with screenId tolerance', async () => {
+        const outcomePromise = Purchasely.presentation.placement('placement1').build().display();
 
-      Purchasely.presentPresentationForPlacement('p', null, 'fullScreen', success, jest.fn(), { onPresented, onCloseRequested });
+        const call = execCallFor('presentPresentationForPlacement');
+        call[0]({
+          result: 1, // legacy field: not part of the v6 builder's outcome contract
+          purchaseResult: 'purchased',
+          plan: { name: 'Plus' },
+          closeReason: null,
+          error: null,
+          presentation: { id: 'screen-id-only' }, // no screenId key: exercises the fallback
+        });
 
-      const dispatch = mockExec.mock.calls[0][0];
-      dispatch({ event: 'presented', presentation: { screenId: 's' } });
-      dispatch({ event: 'closeRequested' });
-      dispatch({ result: 1, purchaseResult: 'cancelled', closeReason: 'button' });
+        const outcome = await outcomePromise;
+        expect(outcome).toEqual({
+          presentation: fullPresentation({ screenId: 'screen-id-only' }),
+          purchaseResult: 'purchased',
+          plan: { name: 'Plus' },
+          closeReason: null,
+          error: null,
+        });
+        expect(outcome.result).toBeUndefined();
+      });
 
-      expect(onPresented).toHaveBeenCalledWith({ screenId: 's' }, null);
-      expect(onCloseRequested).toHaveBeenCalledTimes(1);
-      expect(success).toHaveBeenCalledWith({ result: 1, purchaseResult: 'cancelled', closeReason: 'button' });
+      it('synthesizes an outcome carrying `error` when the native call fails, without rejecting', async () => {
+        const outcomePromise = Purchasely.presentation.placement('placement1').build().display();
+
+        const call = execCallFor('presentPresentationForPlacement');
+        call[1]('Presentation not loaded'); // native error callback
+
+        const outcome = await outcomePromise;
+        expect(outcome.error).toBe('Presentation not loaded');
+        expect(outcome.presentation).toBeNull();
+        expect(outcome.closeReason).toBeNull();
+      });
+    });
+
+    describe('preload() -> display() re-display', () => {
+      it('preload() resolves a screenId-normalized presentation, and the follow-up display() re-displays it via presentPresentation carrying the native handle', async () => {
+        const request = Purchasely.presentation.placement('placement1').build();
+
+        const preloadPromise = request.preload();
+        const fetchCall = execCallFor('fetchPresentation');
+        expect(fetchCall[4]).toEqual(['placement1', null, null]);
+
+        const rawFetched = { screenId: 'onboarding-screen', placementId: 'placement1', fetchId: 'ply_fetch_123' };
+        fetchCall[0](rawFetched);
+
+        const presentation = await preloadPromise;
+        expect(presentation).toEqual(fullPresentation({ screenId: 'onboarding-screen', placementId: 'placement1' }));
+        // The native re-display handle (fetchId) is never exposed on the returned object.
+        expect(presentation.fetchId).toBeUndefined();
+
+        const outcomePromise = request.display();
+        const displayCall = execCallFor('presentPresentation');
+        // The exact raw fetch payload (with its private handle) is forwarded as-is.
+        expect(displayCall[4][0]).toBe(rawFetched);
+        displayCall[0]({ closeReason: 'programmatic' });
+
+        const outcome = await outcomePromise;
+        expect(outcome.closeReason).toBe('programmatic');
+      });
+
+      it('rejects preload() on native failure', async () => {
+        const request = Purchasely.presentation.screen('screen1').build();
+        const preloadPromise = request.preload();
+
+        const fetchCall = execCallFor('fetchPresentation');
+        fetchCall[1]('Screen not found');
+
+        await expect(preloadPromise).rejects.toEqual({ message: 'Screen not found' });
+      });
+    });
+
+    describe('display() direct (no prior preload())', () => {
+      it('calls the matching present* action directly, without ever calling fetchPresentation', async () => {
+        mockExec.mockClear();
+        const outcomePromise = Purchasely.presentation.screen('screen1').build().display();
+
+        expect(mockExec.mock.calls.some((c) => c[3] === 'fetchPresentation')).toBe(false);
+        expect(mockExec.mock.calls.some((c) => c[3] === 'presentPresentationWithIdentifier')).toBe(true);
+
+        const call = execCallFor('presentPresentationWithIdentifier');
+        call[0]({ closeReason: 'button' });
+        await outcomePromise;
+      });
+    });
+
+    describe('request.close()', () => {
+      it('delegates to closeAllScreens (current bridge semantics)', () => {
+        mockExec.mockClear();
+        const request = Purchasely.presentation.placement('placement1').build();
+
+        request.close();
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'closeAllScreens',
+          []
+        );
+      });
+    });
+
+    describe('request.back()', () => {
+      it('calls exec with the backPresentation native action', () => {
+        mockExec.mockClear();
+        const request = Purchasely.presentation.placement('placement1').build();
+
+        request.back();
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'backPresentation',
+          []
+        );
+      });
     });
   });
 
@@ -628,75 +779,6 @@ describe('Purchasely', () => {
         'Purchasely',
         'removeDefaultPresentationDismissHandler',
         []
-      );
-    });
-  });
-
-  describe('fetchPresentation', () => {
-    it('should call exec with correct parameters', () => {
-      const success = jest.fn();
-      const error = jest.fn();
-
-      Purchasely.fetchPresentation('presentation1', 'content1', success, error);
-
-      expect(mockExec).toHaveBeenCalledWith(
-        success,
-        error,
-        'Purchasely',
-        'fetchPresentation',
-        [null, 'presentation1', 'content1']
-      );
-    });
-  });
-
-  describe('fetchPresentationForPlacement', () => {
-    it('should call exec with correct parameters', () => {
-      const success = jest.fn();
-      const error = jest.fn();
-
-      Purchasely.fetchPresentationForPlacement('placement1', 'content1', success, error);
-
-      expect(mockExec).toHaveBeenCalledWith(
-        success,
-        error,
-        'Purchasely',
-        'fetchPresentation',
-        ['placement1', null, 'content1']
-      );
-    });
-  });
-
-  describe('fetchPresentationForDefault', () => {
-    it('should call exec with both ids null', () => {
-      const success = jest.fn();
-      const error = jest.fn();
-
-      Purchasely.fetchPresentationForDefault('content1', success, error);
-
-      expect(mockExec).toHaveBeenCalledWith(
-        success,
-        error,
-        'Purchasely',
-        'fetchPresentation',
-        [null, null, 'content1']
-      );
-    });
-  });
-
-  describe('presentPresentation', () => {
-    it('should call exec with a transition object', () => {
-      const success = jest.fn();
-      const error = jest.fn();
-      const presentation = { id: 'test' };
-
-      Purchasely.presentPresentation(presentation, Purchasely.TransitionType.fullScreen, '#FFFFFF', success, error);
-
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.any(Function),
-        error,
-        'Purchasely',
-        'presentPresentation',
-        [presentation, { type: 'fullScreen' }, '#FFFFFF']
       );
     });
   });
@@ -1048,20 +1130,6 @@ describe('Purchasely', () => {
         expect.any(Function),
         'Purchasely',
         'closeAllScreens',
-        []
-      );
-    });
-  });
-
-  describe('backPresentation', () => {
-    it('should call exec with correct parameters', () => {
-      Purchasely.backPresentation();
-
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.any(Function),
-        expect.any(Function),
-        'Purchasely',
-        'backPresentation',
         []
       );
     });
@@ -1471,6 +1539,24 @@ describe('Purchasely', () => {
       expect(Purchasely.presentPlanWithIdentifier).toBeUndefined();
       expect(Purchasely.showPresentation).toBeUndefined();
       expect(Purchasely.hidePresentation).toBeUndefined();
+    });
+
+    // The imperative presentation surface is replaced by the Purchasely.presentation
+    // builder (see the 'presentation builder (v6)' suite above).
+    it('removes the imperative presentation surface in favor of Purchasely.presentation', () => {
+      expect(Purchasely.fetchPresentation).toBeUndefined();
+      expect(Purchasely.fetchPresentationForPlacement).toBeUndefined();
+      expect(Purchasely.fetchPresentationForDefault).toBeUndefined();
+      expect(Purchasely.presentPresentationWithIdentifier).toBeUndefined();
+      expect(Purchasely.presentPresentationForPlacement).toBeUndefined();
+      expect(Purchasely.presentPresentationForDefault).toBeUndefined();
+      expect(Purchasely.presentPresentation).toBeUndefined();
+      expect(Purchasely.backPresentation).toBeUndefined();
+
+      expect(typeof Purchasely.presentation.placement).toBe('function');
+      expect(typeof Purchasely.presentation.screen).toBe('function');
+      expect(typeof Purchasely.presentation.defaultSource).toBe('function');
+      expect(typeof Purchasely.presentation.default).toBe('function');
     });
 
     it('removes the single global action interceptor in favor of interceptAction(kind, handler)', () => {

--- a/purchasely/__tests__/Purchasely.test.js
+++ b/purchasely/__tests__/Purchasely.test.js
@@ -99,6 +99,14 @@ describe('Purchasely', () => {
       });
     });
 
+    describe('BillingPlanType', () => {
+      it('should have correct billing plan type values (iOS 26.4+ commitment, Apple only)', () => {
+        expect(Purchasely.BillingPlanType.unspecified).toBe(0);
+        expect(Purchasely.BillingPlanType.upFront).toBe(1);
+        expect(Purchasely.BillingPlanType.monthly).toBe(2);
+      });
+    });
+
     describe('RunningMode', () => {
       it('should expose the Purchasely 6.0 running modes by name', () => {
         expect(Purchasely.RunningMode.observer).toBe('observer');
@@ -1064,6 +1072,37 @@ describe('Purchasely', () => {
       );
     });
 
+    // Commitment fields (iOS 26.4+, Apple only) ride on the plan carried by the purchase
+    // payload's `parameters.plan`. The JS layer forwards `parameters` verbatim, so a plan's
+    // `commitmentInfo` must survive untouched — this guards against a future param whitelist
+    // silently dropping it.
+    it('forwards a purchase payload plan carrying commitmentInfo to the handler', async () => {
+      const handler = jest.fn().mockReturnValue(Purchasely.InterceptResult.success);
+      Purchasely.interceptAction('purchase', handler);
+      const nativeSuccess = nativeInterceptorFor('purchase');
+
+      const parameters = {
+        plan: {
+          vendorId: 'plan_monthly_12m',
+          commitmentInfo: [
+            {
+              billingPlanType: Purchasely.BillingPlanType.monthly,
+              billingPrice: 9.99,
+              billingPeriod: 'P1M',
+              totalPrice: 119.88,
+              totalPeriod: 'P1Y',
+              totalDuration: 12,
+            },
+          ],
+        },
+      };
+      nativeSuccess({ action: 'purchase', callbackId: 'purchase#c', info: null, parameters });
+      await flush();
+
+      expect(handler).toHaveBeenCalledWith(null, parameters);
+      expect(handler.mock.calls[0][1].plan.commitmentInfo[0].billingPlanType).toBe(2);
+    });
+
     it('ignores events whose action does not match the registered kind', async () => {
       const handler = jest.fn();
       Purchasely.interceptAction('restore', handler);
@@ -1577,30 +1616,30 @@ describe('Purchasely', () => {
 
   describe('Dynamic Offerings (PAR-05)', () => {
     describe('setDynamicOffering', () => {
-      it('should call exec with correct parameters', () => {
+      it('should call exec with correct parameters, forwarding billingPlanType', () => {
         const success = jest.fn();
         const error = jest.fn();
 
-        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', 'offer_vendor_id', success, error);
+        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', 'offer_vendor_id', Purchasely.BillingPlanType.monthly, success, error);
 
         expect(mockExec).toHaveBeenCalledWith(
           success,
           error,
           'Purchasely',
           'setDynamicOffering',
-          ['ref_1', 'plan_vendor_id', 'offer_vendor_id']
+          ['ref_1', 'plan_vendor_id', 'offer_vendor_id', 2]
         );
       });
 
-      it('should forward a null offerVendorId when none is given', () => {
-        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', null, jest.fn(), jest.fn());
+      it('should forward a null offerVendorId and default billingPlanType to unspecified when omitted', () => {
+        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', null, undefined, jest.fn(), jest.fn());
 
         expect(mockExec).toHaveBeenCalledWith(
           expect.any(Function),
           expect.any(Function),
           'Purchasely',
           'setDynamicOffering',
-          ['ref_1', 'plan_vendor_id', null]
+          ['ref_1', 'plan_vendor_id', null, 0]
         );
       });
     });

--- a/purchasely/__tests__/Purchasely.test.js
+++ b/purchasely/__tests__/Purchasely.test.js
@@ -47,6 +47,9 @@ describe('Purchasely', () => {
         expect(Purchasely.Attribute.APPSFLYER_ID).toBe(5);
         expect(Purchasely.Attribute.AMPLITUDE_USER_ID).toBe(16);
         expect(Purchasely.Attribute.BATCH_CUSTOM_USER_ID).toBe(20);
+        // ENM-02 / REC-11
+        expect(Purchasely.Attribute.ONESIGNAL_USER_ID).toBe(21);
+        expect(Purchasely.Attribute.oneSignalPlayerId).toBeUndefined();
       });
     });
 
@@ -270,7 +273,18 @@ describe('Purchasely', () => {
     });
   });
 
-  describe('addEventsListener', () => {
+  describe('addEventListener (canonical, REC-18/PAR-18)', () => {
+    it('should call exec with correct parameters', () => {
+      const success = jest.fn();
+      const error = jest.fn();
+
+      Purchasely.addEventListener(success, error);
+
+      expect(mockExec).toHaveBeenCalledWith(success, error, 'Purchasely', 'addEventsListener', []);
+    });
+  });
+
+  describe('addEventsListener (deprecated alias)', () => {
     it('should call exec with correct parameters', () => {
       const success = jest.fn();
       const error = jest.fn();
@@ -292,7 +306,21 @@ describe('Purchasely', () => {
     });
   });
 
-  describe('removeEventsListener', () => {
+  describe('removeEventListener (canonical, REC-18/PAR-18)', () => {
+    it('should call exec with correct parameters', () => {
+      Purchasely.removeEventListener();
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Function),
+        'Purchasely',
+        'removeEventsListener',
+        []
+      );
+    });
+  });
+
+  describe('removeEventsListener (deprecated alias)', () => {
     it('should call exec with correct parameters', () => {
       Purchasely.removeEventsListener();
 
@@ -331,6 +359,17 @@ describe('Purchasely', () => {
     });
   });
 
+  describe('isAnonymous (REC-12 / PAR-04)', () => {
+    it('should call exec with correct parameters', () => {
+      const success = jest.fn();
+      const error = jest.fn();
+
+      Purchasely.isAnonymous(success, error);
+
+      expect(mockExec).toHaveBeenCalledWith(success, error, 'Purchasely', 'isAnonymous', []);
+    });
+  });
+
   describe('userLogin', () => {
     it('should call exec with correct parameters', () => {
       const success = jest.fn();
@@ -348,7 +387,7 @@ describe('Purchasely', () => {
   });
 
   describe('userLogout', () => {
-    it('should call exec with correct parameters', () => {
+    it('defaults clearUserAttributes to true when omitted (PAR-30)', () => {
       Purchasely.userLogout();
 
       expect(mockExec).toHaveBeenCalledWith(
@@ -356,7 +395,19 @@ describe('Purchasely', () => {
         expect.any(Function),
         'Purchasely',
         'userLogout',
-        []
+        [true]
+      );
+    });
+
+    it('forwards an explicit clearUserAttributes value', () => {
+      Purchasely.userLogout(false);
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Function),
+        'Purchasely',
+        'userLogout',
+        [false]
       );
     });
   });
@@ -515,7 +566,7 @@ describe('Purchasely', () => {
       );
     });
 
-    it('should default to fullScreen when no displayMode is provided (normalizeTransition default)', () => {
+    it('should send no transition when no displayMode is provided, so the backend default is honored (CDV-W-12)', () => {
       const success = jest.fn();
       const error = jest.fn();
 
@@ -526,7 +577,7 @@ describe('Purchasely', () => {
         error,
         'Purchasely',
         'presentPresentationForPlacement',
-        ['placement1', 'content1', { type: 'fullScreen' }]
+        ['placement1', 'content1', undefined]
       );
     });
   });
@@ -888,7 +939,7 @@ describe('Purchasely', () => {
   });
 
   describe('userSubscriptions', () => {
-    it('should call exec with correct parameters', () => {
+    it('defaults invalidateCache to false when omitted (PAR-29)', () => {
       const success = jest.fn();
       const error = jest.fn();
 
@@ -899,13 +950,28 @@ describe('Purchasely', () => {
         expect.any(Function),
         'Purchasely',
         'userSubscriptions',
-        []
+        [false]
+      );
+    });
+
+    it('forwards an explicit invalidateCache value', () => {
+      const success = jest.fn();
+      const error = jest.fn();
+
+      Purchasely.userSubscriptions(success, error, true);
+
+      expect(mockExec).toHaveBeenCalledWith(
+        success,
+        expect.any(Function),
+        'Purchasely',
+        'userSubscriptions',
+        [true]
       );
     });
   });
 
   describe('userSubscriptionsHistory', () => {
-    it('should call exec with correct parameters', () => {
+    it('defaults invalidateCache to false when omitted (PAR-29)', () => {
       const success = jest.fn();
       const error = jest.fn();
 
@@ -916,7 +982,22 @@ describe('Purchasely', () => {
         expect.any(Function),
         'Purchasely',
         'userSubscriptionsHistory',
-        []
+        [false]
+      );
+    });
+
+    it('forwards an explicit invalidateCache value', () => {
+      const success = jest.fn();
+      const error = jest.fn();
+
+      Purchasely.userSubscriptionsHistory(success, error, true);
+
+      expect(mockExec).toHaveBeenCalledWith(
+        success,
+        expect.any(Function),
+        'Purchasely',
+        'userSubscriptionsHistory',
+        [true]
       );
     });
   });
@@ -935,15 +1016,38 @@ describe('Purchasely', () => {
     });
   });
 
-  describe('closePresentation', () => {
+  describe('closeAllScreens', () => {
     it('should call exec with correct parameters', () => {
+      const success = jest.fn();
+      const error = jest.fn();
+
+      Purchasely.closeAllScreens(success, error);
+
+      expect(mockExec).toHaveBeenCalledWith(success, error, 'Purchasely', 'closeAllScreens', []);
+    });
+
+    it('should default callbacks when none provided', () => {
+      Purchasely.closeAllScreens();
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Function),
+        'Purchasely',
+        'closeAllScreens',
+        []
+      );
+    });
+  });
+
+  describe('closePresentation (deprecated alias of closeAllScreens)', () => {
+    it('should delegate to closeAllScreens', () => {
       Purchasely.closePresentation();
 
       expect(mockExec).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),
         'Purchasely',
-        'closePresentation',
+        'closeAllScreens',
         []
       );
     });
@@ -1142,6 +1246,79 @@ describe('Purchasely', () => {
         );
       });
     });
+
+    describe('getBuiltInAttributes (PAR-07)', () => {
+      it('should call exec with correct parameters', () => {
+        const success = jest.fn();
+        const error = jest.fn();
+
+        Purchasely.getBuiltInAttributes(success, error);
+
+        expect(mockExec).toHaveBeenCalledWith(success, error, 'Purchasely', 'getBuiltInAttributes', []);
+      });
+    });
+
+    describe('getBuiltInAttribute (PAR-07)', () => {
+      it('should call exec with correct parameters', () => {
+        const success = jest.fn();
+        const error = jest.fn();
+
+        Purchasely.getBuiltInAttribute('ply_session_count', success, error);
+
+        expect(mockExec).toHaveBeenCalledWith(success, error, 'Purchasely', 'getBuiltInAttribute', ['ply_session_count']);
+      });
+    });
+
+    describe('userAttributes (REC-12 / PAR-03)', () => {
+      it('should call exec with correct parameters', () => {
+        const success = jest.fn();
+        const error = jest.fn();
+
+        Purchasely.userAttributes(success, error);
+
+        expect(mockExec).toHaveBeenCalledWith(success, error, 'Purchasely', 'userAttributes', []);
+      });
+    });
+
+    describe('incrementUserAttribute (REC-12 / PAR-02)', () => {
+      it('should call exec with correct parameters', () => {
+        Purchasely.incrementUserAttribute('counter', 5);
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'incrementUserAttribute',
+          ['counter', 5]
+        );
+      });
+
+      it('should forward an omitted value as-is (native defaults it to 1)', () => {
+        Purchasely.incrementUserAttribute('counter');
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'incrementUserAttribute',
+          ['counter', undefined]
+        );
+      });
+    });
+
+    describe('decrementUserAttribute (REC-12 / PAR-02)', () => {
+      it('should call exec with correct parameters', () => {
+        Purchasely.decrementUserAttribute('counter', 3);
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'decrementUserAttribute',
+          ['counter', 3]
+        );
+      });
+    });
   });
 
   describe('isEligibleForIntroOffer', () => {
@@ -1211,6 +1388,76 @@ describe('Purchasely', () => {
         'setDebugMode',
         [true]
       );
+    });
+  });
+
+  describe('Dynamic Offerings (PAR-05)', () => {
+    describe('setDynamicOffering', () => {
+      it('should call exec with correct parameters', () => {
+        const success = jest.fn();
+        const error = jest.fn();
+
+        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', 'offer_vendor_id', success, error);
+
+        expect(mockExec).toHaveBeenCalledWith(
+          success,
+          error,
+          'Purchasely',
+          'setDynamicOffering',
+          ['ref_1', 'plan_vendor_id', 'offer_vendor_id']
+        );
+      });
+
+      it('should forward a null offerVendorId when none is given', () => {
+        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', null, jest.fn(), jest.fn());
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'setDynamicOffering',
+          ['ref_1', 'plan_vendor_id', null]
+        );
+      });
+    });
+
+    describe('getDynamicOfferings', () => {
+      it('should call exec with correct parameters', () => {
+        const success = jest.fn();
+        const error = jest.fn();
+
+        Purchasely.getDynamicOfferings(success, error);
+
+        expect(mockExec).toHaveBeenCalledWith(success, error, 'Purchasely', 'getDynamicOfferings', []);
+      });
+    });
+
+    describe('removeDynamicOffering', () => {
+      it('should call exec with correct parameters', () => {
+        Purchasely.removeDynamicOffering('ref_1');
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'removeDynamicOffering',
+          ['ref_1']
+        );
+      });
+    });
+
+    describe('clearDynamicOfferings', () => {
+      it('should call exec with correct parameters', () => {
+        Purchasely.clearDynamicOfferings();
+
+        expect(mockExec).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          'Purchasely',
+          'clearDynamicOfferings',
+          []
+        );
+      });
     });
   });
 

--- a/purchasely/example/e2e/README.md
+++ b/purchasely/example/e2e/README.md
@@ -16,8 +16,8 @@ Cordova imperative API. They are **not** part of the PR-gating `ci.yml`; they ru
 
 | Suite | File | Gate | Notes |
 |-------|------|------|-------|
-| bridge | `specs/bridge.e2e.js` | **hard** | anonymous id, allProducts, fetchPresentationForPlacement, synchronize completion, user-attribute round-trip |
-| dismiss | `specs/dismiss.e2e.js` | best-effort | present placement + programmatic close → dismiss outcome + `closeReason` (needs a paywall to render) |
+| bridge | `specs/bridge.e2e.js` | **hard** | anonymous id, allProducts, fetchPresentationForPlacement, synchronize completion, user-attribute round-trip (string/int/boolean), userSubscriptions |
+| dismiss | `specs/dismiss.e2e.js` | best-effort | present placement or default presentation + programmatic close → dismiss outcome + `closeReason` (needs a paywall to render) |
 
 Best-effort suites emit `::warning::` on failure and do not fail the job (native/paywall
 rendering is flaky in CI — same policy as the Flutter suite). Each suite retries up to 3×.

--- a/purchasely/example/e2e/helpers/driver.js
+++ b/purchasely/example/e2e/helpers/driver.js
@@ -67,4 +67,61 @@ async function callBridge(method, args = [], timeoutMs = 30000) {
   );
 }
 
-module.exports = { switchToWebview, switchToNative, waitForPurchaselyReady, callBridge };
+// Drive the v6 presentation builder (Purchasely.presentation) from WEBVIEW context and
+// resolve with { ok, value } / { ok:false, error } -- same contract as callBridge, since
+// fetchPresentation*/presentPresentation* (and their (args..., success, error) shape that
+// callBridge drives) were removed in favor of the promise-based builder.
+// `source` is 'placement' | 'screen' | 'defaultSource'; `sourceId` is the placement/screen
+// id (omit for 'defaultSource'); `action` is 'preload' or 'display'; `transition` is passed
+// to display() when action is 'display'. Stashes the built request on
+// `window.__plyLastRequest` so a follow-up closeCurrentPresentation()/backCurrentPresentation()
+// call in the same test can drive it (mirrors closePresentation()/backPresentation() acting
+// on the natively-tracked current presentation pre-builder).
+async function callPresentation(source, sourceId, action, transition, timeoutMs = 90000) {
+  return browser.executeAsync(
+    function (source, sourceId, action, transition, timeoutMs, done) {
+      var settled = false;
+      var finish = function (payload) {
+        if (settled) return;
+        settled = true;
+        done(payload);
+      };
+      setTimeout(function () { finish({ ok: false, error: 'timeout' }); }, timeoutMs);
+      try {
+        var builder = sourceId
+          ? window.Purchasely.presentation[source](sourceId)
+          : window.Purchasely.presentation[source]();
+        var request = builder.build();
+        window.__plyLastRequest = request;
+        var promise = action === 'preload' ? request.preload() : request.display(transition);
+        promise.then(
+          function (value) { finish({ ok: true, value: value }); },
+          function (error) { finish({ ok: false, error: String(error) }); }
+        );
+      } catch (e) {
+        finish({ ok: false, error: String(e) });
+      }
+    },
+    source,
+    sourceId,
+    action,
+    transition,
+    timeoutMs
+  );
+}
+
+// Close the presentation driven by the last callPresentation() request (WEBVIEW context).
+async function closeCurrentPresentation() {
+  return browser.execute(function () {
+    if (window.__plyLastRequest) window.__plyLastRequest.close();
+  });
+}
+
+module.exports = {
+  switchToWebview,
+  switchToNative,
+  waitForPurchaselyReady,
+  callBridge,
+  callPresentation,
+  closeCurrentPresentation,
+};

--- a/purchasely/example/e2e/specs/bridge.e2e.js
+++ b/purchasely/example/e2e/specs/bridge.e2e.js
@@ -48,4 +48,29 @@ describe('Purchasely bridge (WEBVIEW context)', () => {
     expect(res.ok).toBe(true);
     expect(res.value).toBe('e2e_value');
   });
+
+  // user-attribute round-trip, int variant
+  it('setUserAttributeWithInt then userAttribute round-trips', async () => {
+    await callBridge('setUserAttributeWithInt', ['e2e_key_int', 7, 'ESSENTIAL']);
+    const res = await callBridge('userAttribute', ['e2e_key_int']);
+    expect(res.ok).toBe(true);
+    expect(res.value).toBe(7);
+  });
+
+  // user-attribute round-trip, boolean variant (see CDV-W-09: Android returns 0/1,
+  // iOS returns a real boolean -- assert loosely on truthiness rather than strict type).
+  it('setUserAttributeWithBoolean then userAttribute round-trips', async () => {
+    await callBridge('setUserAttributeWithBoolean', ['e2e_key_bool', true, 'ESSENTIAL']);
+    const res = await callBridge('userAttribute', ['e2e_key_bool']);
+    expect(res.ok).toBe(true);
+    expect(res.value).toBeTruthy();
+  });
+
+  // userSubscriptions on a fresh anonymous user: no purchases exist, so this must
+  // resolve with an empty (not error) list rather than actually validating any store.
+  it('userSubscriptions returns a list', async () => {
+    const res = await callBridge('userSubscriptions');
+    expect(res.ok).toBe(true);
+    expect(Array.isArray(res.value)).toBe(true);
+  });
 });

--- a/purchasely/example/e2e/specs/bridge.e2e.js
+++ b/purchasely/example/e2e/specs/bridge.e2e.js
@@ -1,7 +1,7 @@
 // Deterministic Dart<->native bridge assertions (no native taps). HARD gate — these
 // must pass. Mirrors the Flutter E2E_TEST_INDEX suite T1/T3/T5/T6 adapted to the
 // Cordova imperative API.
-const { waitForPurchaselyReady, callBridge } = require('../helpers/driver');
+const { waitForPurchaselyReady, callBridge, callPresentation } = require('../helpers/driver');
 
 const PLACEMENT = process.env.PURCHASELY_E2E_PLACEMENT || 'ONBOARDING';
 
@@ -25,13 +25,17 @@ describe('Purchasely bridge (WEBVIEW context)', () => {
     expect(Array.isArray(res.value)).toBe(true);
   });
 
-  // T3 — preload a presentation for a placement
-  it('fetchPresentationForPlacement returns a presentation object', async () => {
-    const res = await callBridge('fetchPresentationForPlacement', [PLACEMENT, null]);
+  // T3 — preload a presentation for a placement (was fetchPresentationForPlacement;
+  // now Purchasely.presentation.placement(id).build().preload())
+  it('presentation.placement(...).build().preload() returns a presentation object', async () => {
+    const res = await callPresentation('placement', PLACEMENT, 'preload');
     expect(res.ok).toBe(true);
     expect(res.value).toBeDefined();
-    // v6 presentation carries an id/type so it can later be displayed.
+    // v6 presentation normalizes screenId as the authoritative identifier.
     expect(res.value === null || typeof res.value === 'object').toBe(true);
+    if (res.value) {
+      expect(typeof res.value.screenId).toBe('string');
+    }
   });
 
   // T6 — synchronize now reports completion (v6 change). On a bare emulator/simulator

--- a/purchasely/example/e2e/specs/bridge.e2e.js
+++ b/purchasely/example/e2e/specs/bridge.e2e.js
@@ -57,13 +57,13 @@ describe('Purchasely bridge (WEBVIEW context)', () => {
     expect(res.value).toBe(7);
   });
 
-  // user-attribute round-trip, boolean variant (see CDV-W-09: Android returns 0/1,
-  // iOS returns a real boolean -- assert loosely on truthiness rather than strict type).
+  // user-attribute round-trip, boolean variant (CDV-W-09 fixed: both platforms now
+  // return a real JSON boolean, so this asserts strict equality, not just truthiness).
   it('setUserAttributeWithBoolean then userAttribute round-trips', async () => {
     await callBridge('setUserAttributeWithBoolean', ['e2e_key_bool', true, 'ESSENTIAL']);
     const res = await callBridge('userAttribute', ['e2e_key_bool']);
     expect(res.ok).toBe(true);
-    expect(res.value).toBeTruthy();
+    expect(res.value).toBe(true);
   });
 
   // userSubscriptions on a fresh anonymous user: no purchases exist, so this must

--- a/purchasely/example/e2e/specs/dismiss.e2e.js
+++ b/purchasely/example/e2e/specs/dismiss.e2e.js
@@ -34,4 +34,26 @@ describe('Presentation dismiss outcome', () => {
     }
     await switchToNative().catch(() => {});
   });
+
+  // v6 default (audience-targeted) presentation: same shape as the placement flow above,
+  // just with no placement/presentation id. Best-effort: depends on a default audience
+  // being configured on the backend for this app id.
+  it('presentPresentationForDefault + closePresentation delivers a dismiss outcome', async () => {
+    const outcomePromise = callBridge(
+      'presentPresentationForDefault',
+      [null, 'fullScreen'],
+      90000
+    );
+
+    await browser.pause(6000);
+    await callBridge('closePresentation');
+
+    const outcome = await outcomePromise;
+    expect(outcome.ok).toBe(true);
+    expect(outcome.value).toBeDefined();
+    if (outcome.value && outcome.value.closeReason) {
+      expect(typeof outcome.value.closeReason).toBe('string');
+    }
+    await switchToNative().catch(() => {});
+  });
 });

--- a/purchasely/example/e2e/specs/dismiss.e2e.js
+++ b/purchasely/example/e2e/specs/dismiss.e2e.js
@@ -1,7 +1,12 @@
 // Presentation display + dismiss outcome. BEST-EFFORT (non-blocking in CI): depends on
 // a paywall actually rendering for the configured placement against the real backend.
 // Mirrors E2E_TEST_INDEX T8/T12 adapted to the Cordova imperative API.
-const { waitForPurchaselyReady, callBridge, switchToNative } = require('../helpers/driver');
+const {
+  waitForPurchaselyReady,
+  callPresentation,
+  closeCurrentPresentation,
+  switchToNative,
+} = require('../helpers/driver');
 
 const PLACEMENT = process.env.PURCHASELY_E2E_PLACEMENT || 'ONBOARDING';
 
@@ -10,20 +15,18 @@ describe('Presentation dismiss outcome', () => {
     await waitForPurchaselyReady();
   });
 
-  // T8/T12 — the present* success callback IS the per-presentation dismiss outcome.
+  // T8/T12 — display() resolves with the per-presentation dismiss outcome (was the
+  // presentPresentationForPlacement success callback; closePresentation() is now
+  // request.close(), driven here via closeCurrentPresentation()).
   // Present a placement, close it programmatically, and assert the outcome fires with a
   // closeReason.
-  it('presentPresentationForPlacement + closePresentation delivers a dismiss outcome', async () => {
-    // Kick off the presentation; do NOT await (the callback resolves at dismiss).
-    const outcomePromise = callBridge(
-      'presentPresentationForPlacement',
-      [PLACEMENT, null, 'fullScreen'],
-      90000
-    );
+  it('presentation.placement(...).build().display() + request.close() delivers a dismiss outcome', async () => {
+    // Kick off the presentation; do NOT await (the promise resolves at dismiss).
+    const outcomePromise = callPresentation('placement', PLACEMENT, 'display', 'fullScreen', 90000);
 
     // Give the paywall time to render, then close it programmatically from the bridge.
     await browser.pause(6000);
-    await callBridge('closePresentation');
+    await closeCurrentPresentation();
 
     const outcome = await outcomePromise;
     expect(outcome.ok).toBe(true);
@@ -36,17 +39,13 @@ describe('Presentation dismiss outcome', () => {
   });
 
   // v6 default (audience-targeted) presentation: same shape as the placement flow above,
-  // just with no placement/presentation id. Best-effort: depends on a default audience
-  // being configured on the backend for this app id.
-  it('presentPresentationForDefault + closePresentation delivers a dismiss outcome', async () => {
-    const outcomePromise = callBridge(
-      'presentPresentationForDefault',
-      [null, 'fullScreen'],
-      90000
-    );
+  // just with no placement/screen id (was presentPresentationForDefault). Best-effort:
+  // depends on a default audience being configured on the backend for this app id.
+  it('presentation.defaultSource().build().display() + request.close() delivers a dismiss outcome', async () => {
+    const outcomePromise = callPresentation('defaultSource', null, 'display', 'fullScreen', 90000);
 
     await browser.pause(6000);
-    await callBridge('closePresentation');
+    await closeCurrentPresentation();
 
     const outcome = await outcomePromise;
     expect(outcome.ok).toBe(true);

--- a/purchasely/example/www/js/index.js
+++ b/purchasely/example/www/js/index.js
@@ -295,72 +295,76 @@ function onPurchaselySdkReady() {
 	Purchasely.clearBuiltInAttributes();
 }
 
+// Purchasely 6.0: `back()`/`close()` live on the request, not as bare top-level calls
+// (backPresentation() was removed). The example keeps a reference to the last request
+// it built/displayed so the "Back presentation" button below has something to drive.
+var currentPresentationRequest = null;
+
 function openPresentation() {
-	Purchasely.presentPresentationForPlacement(
-		'ONBOARDING', //placementId
-		null, //contentId
-		Purchasely.TransitionType.fullScreen, //display mode (string) — or a transition object, see below
-		(callback) => {
-			console.log('[openPresentation] onDismissed — purchaseResult=' + callback.purchaseResult + ' — outcome: ' + safeStringify(callback));
-			if(callback.result == Purchasely.PurchaseResult.CANCELLED) {
-				console.log("User cancelled purchased - close reason " + callback.closeReason);
+	// Purchasely 6.0: the v6 builder — pick a source (.placement/.screen/.defaultSource),
+	// chain lifecycle callbacks, .build(), then .display(transition?). display() resolves
+	// at dismiss with a 5-field outcome: { presentation, purchaseResult, plan, closeReason, error }.
+	currentPresentationRequest = Purchasely.presentation
+		.placement('ONBOARDING')
+		.onPresented((presentation, error) => {
+			console.log('[openPresentation] onPresented — ' + (presentation ? presentation.screenId : '') + (error ? ' error=' + error : ''));
+		})
+		.onCloseRequested(() => {
+			console.log('[openPresentation] onCloseRequested');
+		})
+		.build();
+
+	currentPresentationRequest
+		.display(Purchasely.TransitionType.fullScreen) //display mode (string) — or a transition object, see below
+		.then((outcome) => {
+			console.log('[openPresentation] onDismissed — purchaseResult=' + outcome.purchaseResult + ' — outcome: ' + safeStringify(outcome));
+			if (outcome.error) {
+				console.log("[openPresentation] error: " + outcome.error);
+			} else if (outcome.purchaseResult === 'purchased' || outcome.purchaseResult === 'restored') {
+				console.log("User purchased " + (outcome.plan ? outcome.plan.name : ''));
 			} else {
-				console.log("User purchased " + (callback.plan ? callback.plan.name : ''));
+				console.log("User cancelled purchased - close reason " + outcome.closeReason);
 			}
-		},
-		(error) => {
-			console.log("[openPresentation] error: " + error);
-		},
-		// Purchasely 6.0: optional per-request lifecycle callbacks.
-		{
-			onPresented: (presentation, error) => {
-				console.log('[openPresentation] onPresented — ' + (presentation ? presentation.screenId : '') + (error ? ' error=' + error : ''));
-			},
-			onCloseRequested: () => {
-				console.log('[openPresentation] onCloseRequested');
-			}
-		}
-	);
+		});
 
 	// Purchasely 6.0 also supports:
 	//  - a rich transition object for drawer/popin sizing (see fetchPresentation below):
 	//      { type: Purchasely.TransitionType.drawer, dismissible: true,
 	//        height: { type: Purchasely.DimensionType.percentage, value: 0.8 }, backgroundColor: '#000000' }
-	//  - the default (audience-targeted) presentation:
-	//      Purchasely.presentPresentationForDefault(null, Purchasely.TransitionType.fullScreen, ok, err);
-	//      Purchasely.fetchPresentationForDefault(null, onLoaded, err);
+	//  - the default (audience-targeted) presentation, targeted with .defaultSource() (or its
+	//    iOS-style alias .default()):
+	//      Purchasely.presentation.defaultSource().build().display(Purchasely.TransitionType.fullScreen);
 	//  - stopping campaign/deeplink dismiss outcomes:
 	//      Purchasely.removeDefaultPresentationDismissHandler();
 }
 
 function fetchPresentation() {
-	Purchasely.fetchPresentationForPlacement(
-		'flow_demo', //placementId
-		null, //contentId
-		(presentation) => {
-			console.log('[fetchPresentation] onFetched — presentation: ' + safeStringify(presentation));
-			// Rich transition object: drawer at 80% height, dismissible. (iOS applies the
-			// percentage height + dismissible; Android also supports pixel + popin width.)
-			Purchasely.presentPresentation(presentation, {
-				type: Purchasely.TransitionType.drawer,
-				dismissible: true,
-				height: { type: Purchasely.DimensionType.percentage, value: 0.8 }
-			}, null,
-				(callback) => {
-					console.log('[fetchPresentation → presentPresentation] onDismissed — purchaseResult=' + callback.purchaseResult + ' — outcome: ' + safeStringify(callback));
-					if(callback.result == Purchasely.PurchaseResult.CANCELLED) {
-						console.log("User cancelled purchased - close reason " + callback.closeReason);
-					} else {
-						console.log("User purchased " + (callback.plan ? callback.plan.name : ''));
-					}
-				}, (error) => {
-					console.log("[fetchPresentation → presentPresentation] error: " + error);
-				});
-		},
-		(error) => {
-			console.log("[fetchPresentation] error: " + error);
-		}
-	);
+	// Purchasely 6.0: preload() fetches without displaying; the resolved presentation
+	// exposes screenId (the authoritative identifier). Calling display() on the SAME
+	// request re-displays exactly what was preloaded.
+	const request = Purchasely.presentation.placement('flow_demo').build();
+	currentPresentationRequest = request;
+	request.preload().then((presentation) => {
+		console.log('[fetchPresentation] onFetched — presentation: ' + safeStringify(presentation));
+		// Rich transition object: drawer at 80% height, dismissible. (iOS applies the
+		// percentage height + dismissible; Android also supports pixel + popin width.)
+		request.display({
+			type: Purchasely.TransitionType.drawer,
+			dismissible: true,
+			height: { type: Purchasely.DimensionType.percentage, value: 0.8 }
+		}).then((outcome) => {
+			console.log('[fetchPresentation → display] onDismissed — purchaseResult=' + outcome.purchaseResult + ' — outcome: ' + safeStringify(outcome));
+			if (outcome.error) {
+				console.log("[fetchPresentation → display] error: " + outcome.error);
+			} else if (outcome.purchaseResult === 'purchased' || outcome.purchaseResult === 'restored') {
+				console.log("User purchased " + (outcome.plan ? outcome.plan.name : ''));
+			} else {
+				console.log("User cancelled purchased - close reason " + outcome.closeReason);
+			}
+		});
+	}, (error) => {
+		console.log("[fetchPresentation] error: " + safeStringify(error));
+	});
 }
 
 function purchaseWithPlanVendorId() {
@@ -378,7 +382,7 @@ function processToPayment() {
 }
 
 function backPresentation() {
-	Purchasely.backPresentation();
+	if (currentPresentationRequest) currentPresentationRequest.back();
 }
 
 function closePresentation() {

--- a/purchasely/src/android/PurchaselyPlugin.kt
+++ b/purchasely/src/android/PurchaselyPlugin.kt
@@ -72,8 +72,10 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
 
     // Presentation currently displayed (used for back()/close()).
     private var displayedPresentation: PLYPresentationBase.Loaded? = null
-    // Presentations preloaded by fetchPresentation, keyed by a synthetic handle
-    // (the "id" we send back to JS) so presentPresentation can re-display them.
+    // Presentations preloaded by fetchPresentation, keyed by a synthetic handle sent back to
+    // JS under the private `fetchId` key (NOT `id` -- `screenId` is the authoritative public
+    // presentation identifier; `fetchId` is an internal re-display lookup key, never documented
+    // as public API) so presentPresentation can re-display them.
     private val loadedPresentations = ConcurrentHashMap<String, PLYPresentationBase.Loaded>()
 
     override fun onDestroy() {
@@ -619,10 +621,12 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 }
                 val loaded = builder.build().preload()
                 // Synthetic handle so presentPresentation can re-display this preloaded presentation.
+                // Private re-display key: `fetchId`, NOT `id` -- `screenId` (already set by
+                // presentationToMap) is the sole authoritative public identifier.
                 val handle = "ply_fetch_${System.nanoTime()}"
                 loadedPresentations[handle] = loaded
                 val map = presentationToMap(loaded).toMutableMap()
-                map["id"] = handle
+                map["fetchId"] = handle
                 callbackContext.success(JSONObject(map))
             } catch (t: Throwable) {
                 callbackContext.error(t.message ?: "Unable to fetch presentation")
@@ -639,7 +643,13 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
             return
         }
 
-        val handle = if (presentationMap.has("id")) presentationMap.optString("id") else null
+        // Private re-display key: `fetchId` (see fetchPresentation above). `id` is tolerated
+        // as an internal belt-and-braces fallback only -- never a documented public key.
+        val handle = when {
+            presentationMap.has("fetchId") -> presentationMap.optString("fetchId")
+            presentationMap.has("id") -> presentationMap.optString("id")
+            else -> null
+        }
         val loaded = handle?.let { loadedPresentations[it] }
         if (loaded == null) {
             callbackContext.error("presentation cannot be found")

--- a/purchasely/src/android/PurchaselyPlugin.kt
+++ b/purchasely/src/android/PurchaselyPlugin.kt
@@ -90,7 +90,6 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
             when (action) {
                 "start" -> start(args.getJSONObject(0), callbackContext)
 
-                "close" -> close()
                 "addEventsListener" -> addEventsListener(callbackContext)
                 "addUserAttributeListener" -> addUserAttributesListener(callbackContext)
                 "removeUserAttributeListener" -> removeUserAttributesListener()
@@ -310,17 +309,6 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         return result
     }
 
-    private fun close() {
-        defaultCallback = null
-        purchaseCallback = null
-        actionInterceptorCallbacks.clear()
-        pendingInterceptCompletions.clear()
-        displayedPresentation = null
-        // TODO(v6-verify): the global Purchasely.close() teardown was removed/lumped with
-        // presentation close in v6 (Flutter never calls it). Not invoked here to avoid a
-        // reference to a symbol that may no longer exist.
-    }
-
     private fun addUserAttributesListener(callbackContext: CallbackContext) {
         attributesCallback = callbackContext
         Purchasely.userAttributeListener = object: UserAttributeListener {
@@ -399,7 +387,10 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
     }
 
     private fun setLogLevel(logLevel: Int) {
-        Purchasely.logLevel = LogLevel.values()[logLevel]
+        // CDV-W-13: values()[logLevel] throws ArrayIndexOutOfBoundsException for an
+        // out-of-range value, uncaught by execute()'s JSONException-only catch. Reuse the
+        // already-bounded helper start() relies on.
+        Purchasely.logLevel = logLevelFrom(logLevel)
     }
 
     private fun setLanguage(language: String?) {
@@ -743,6 +734,9 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 StoreType.AMAZON_APP_STORE -> StoreType.AMAZON_APP_STORE.ordinal
                 StoreType.HUAWEI_APP_GALLERY -> StoreType.HUAWEI_APP_GALLERY.ordinal
                 StoreType.APPLE_APP_STORE -> StoreType.APPLE_APP_STORE.ordinal
+                // CDV-W-15: NONE/WEB_CHECKOUT_STRIPE have no JS SubscriptionSource case of
+                // their own; both map to `none` (4), matching iOS's PLYSubscriptionSource.None.
+                StoreType.NONE, StoreType.WEB_CHECKOUT_STRIPE -> 4
                 else -> null
             }
             result.put(JSONObject(map))
@@ -1086,7 +1080,12 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
             is JSONArray -> callbackContext.success(result)
             is String -> callbackContext.success(result)
             is Int -> callbackContext.success(result)
-            is Boolean -> callbackContext.success(if (result) 1 else 0)
+            // CDV-W-06: getUserAttributeValueForCordova converts a Float attribute to a Double
+            // (to preserve precision); this branch was missing, so reading back any
+            // setUserAttributeWithDouble value always fell through to the error case below.
+            is Double -> callbackContext.sendPluginResult(PluginResult(PluginResult.Status.OK, result.toFloat()))
+            // CDV-W-09: send a real JSON boolean (matches iOS) instead of 0/1.
+            is Boolean -> callbackContext.sendPluginResult(PluginResult(PluginResult.Status.OK, result))
             else -> callbackContext.error("No user attribute found with $key")
         }
     }
@@ -1147,8 +1146,11 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         }
     }
 
+    // REC-04: iOS-only feature (StoreKit promotional offer signing). No error on Android by
+    // design (Kevin's call) -- signPromotionalOffer resolves as a no-op success so shared JS
+    // calling it unconditionally on both platforms doesn't have to special-case Android.
     private fun signPromotionalOffer(storeProductId: String?, storeOfferId: String?, callbackContext: CallbackContext) {
-        callbackContext.error("No signing required on Android")
+        callbackContext.success()
     }
 
     private fun revokeDataProcessingConsent(purposes: JSONArray?) {
@@ -1215,7 +1217,11 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
             // v6: also expose the string purchaseResult ('purchased'|'cancelled'|'restored'|null)
             // alongside the legacy int `result`, matching the Flutter outcome contract.
             map["purchaseResult"] = outcome.purchaseResult?.name?.lowercase(Locale.US)
-            map["plan"] = transformPlanToMap(outcome.plan)
+            // CDV-W-05: transformPlanToMap(null) returns {} (not null), so setting the key
+            // unconditionally made a naive `if (outcome.plan)` truthy check on Android but
+            // falsy (key omitted) on iOS for the same no-purchase dismissal. Omit the key
+            // entirely when there is no plan, matching iOS.
+            outcome.plan?.let { map["plan"] = transformPlanToMap(it) }
             map["closeReason"] = outcome.closeReason?.value
             map["error"] = outcome.error?.message
             map["presentation"] = outcome.presentation?.let { presentationToMap(it) }

--- a/purchasely/src/android/PurchaselyPlugin.kt
+++ b/purchasely/src/android/PurchaselyPlugin.kt
@@ -77,6 +77,13 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
     // presentation identifier; `fetchId` is an internal re-display lookup key, never documented
     // as public API) so presentPresentation can re-display them.
     private val loadedPresentations = ConcurrentHashMap<String, PLYPresentationBase.Loaded>()
+    // v6: the native SDK fixes onPresented/onCloseRequested at builder.build() time (before
+    // preload()) -- there is no display invocation, hence no CallbackContext, yet at fetch
+    // time. Seeded closures in fetchPresentation() capture the handle and resolve the live
+    // CallbackContext from here lazily, at fire time; presentPresentation() registers the
+    // invocation that's actually re-displaying under the same handle just before calling
+    // display(). Keyed identically to loadedPresentations.
+    private val lifecycleCallbacks = ConcurrentHashMap<String, CallbackContext>()
 
     override fun onDestroy() {
         job.cancel()
@@ -611,6 +618,13 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         callbackContext: CallbackContext) {
         launch {
             try {
+                // Synthetic handle so presentPresentation can re-display this preloaded
+                // presentation. Private re-display key: `fetchId`, NOT `id` -- `screenId`
+                // (already set by presentationToMap) is the sole authoritative public
+                // identifier. Generated up front so the onPresented/onCloseRequested closures
+                // below can capture it -- the native SDK fixes those on the builder, before
+                // preload(), so they must be seeded here rather than at re-display time.
+                val handle = "ply_fetch_${System.nanoTime()}"
                 val builder = PLYPresentationBase.builder().apply {
                     when {
                         placementId != null -> this.placementId(placementId)
@@ -618,12 +632,29 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                         // else: neither id → the default (audience-targeted) presentation
                     }
                     contentId(contentId)
+                    // v6: these fire on whichever invocation ends up re-displaying this
+                    // presentation (via presentPresentation), not this fetch call -- resolve the
+                    // live CallbackContext from lifecycleCallbacks lazily, at fire time, instead
+                    // of capturing this fetch's own (long-finished) callbackContext. If nothing
+                    // is registered yet (fired before any display), it's a silent no-op: there is
+                    // no invocation to observe it.
+                    onPresented { presentation, error ->
+                        val cb = lifecycleCallbacks[handle] ?: return@onPresented
+                        val env = mutableMapOf<String, Any?>("event" to "presented")
+                        presentation?.let { env["presentation"] = presentationToMap(it) }
+                        error?.let { env["error"] = it.message }
+                        val r = PluginResult(PluginResult.Status.OK, JSONObject(env))
+                        r.keepCallback = true
+                        cb.sendPluginResult(r)
+                    }
+                    onCloseRequested {
+                        val cb = lifecycleCallbacks[handle] ?: return@onCloseRequested
+                        val r = PluginResult(PluginResult.Status.OK, JSONObject(mapOf("event" to "closeRequested")))
+                        r.keepCallback = true
+                        cb.sendPluginResult(r)
+                    }
                 }
                 val loaded = builder.build().preload()
-                // Synthetic handle so presentPresentation can re-display this preloaded presentation.
-                // Private re-display key: `fetchId`, NOT `id` -- `screenId` (already set by
-                // presentationToMap) is the sole authoritative public identifier.
-                val handle = "ply_fetch_${System.nanoTime()}"
                 loadedPresentations[handle] = loaded
                 val map = presentationToMap(loaded).toMutableMap()
                 map["fetchId"] = handle
@@ -651,7 +682,7 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
             else -> null
         }
         val loaded = handle?.let { loadedPresentations[it] }
-        if (loaded == null) {
+        if (loaded == null || handle == null) {
             callbackContext.error("presentation cannot be found")
             return
         }
@@ -659,20 +690,34 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         displayedPresentation = loaded
 
         // TODO(v6-verify): loadingBackgroundColor cannot be applied to an already-preloaded
-        // presentation in v6 (colors are builder options set before preload). The re-display
-        // path delivers the dismiss outcome only; onPresented/onCloseRequested are wired on the
-        // direct present* methods (builder-seeded before preload).
+        // presentation in v6 (colors are builder options set before preload).
+        //
+        // v6: onPresented/onCloseRequested were seeded on the builder back in
+        // fetchPresentation() (fixed at build time, before preload -- the native SDK doesn't
+        // allow setting them later) and resolve their live CallbackContext from
+        // lifecycleCallbacks lazily, at fire time. Register THIS invocation's callbackContext
+        // under `handle` before triggering display() so those events reach it, matching the
+        // direct present* path's envelopes exactly (same event/presentation/error keys,
+        // keepCallback=true). Confirmed against the native SDK sources: display(callback) only
+        // replaces onDismissed, never onPresented/onCloseRequested (PLYPresentationBase.
+        // dispatchDisplay).
         //
         // CDV-W-07: resolve directly against this invocation's own callbackContext (no shared
-        // slot), and fail cleanly instead of silently no-op-ing when there's no activity to
-        // post to (the callback would otherwise never resolve).
+        // slot). Remove the registration as soon as this invocation's dismiss outcome is
+        // delivered, or immediately on any early-return error below -- otherwise a failed
+        // display leaves a stale entry routing future lifecycle events to a callback that will
+        // never fire again.
+        lifecycleCallbacks[handle] = callbackContext
+
         val activity = cordova.activity
         if (activity == null) {
+            lifecycleCallbacks.remove(handle)
             callbackContext.error("No activity available to display presentation")
             return
         }
         activity.runOnUiThread {
             loaded.display(activity, transitionFromMap(transition)) { outcome ->
+                lifecycleCallbacks.remove(handle)
                 callbackContext.success(JSONObject(outcomeToMap(outcome)))
             }
         }

--- a/purchasely/src/android/PurchaselyPlugin.kt
+++ b/purchasely/src/android/PurchaselyPlugin.kt
@@ -95,8 +95,9 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 "removeUserAttributeListener" -> removeUserAttributesListener()
                 "removeEventsListener" -> removeEventsListener()
                 "getAnonymousUserId" -> getAnonymousUserId(callbackContext)
+                "isAnonymous" -> isAnonymous(callbackContext)
                 "userLogin" -> userLogin(getStringFromJson(args.getString(0)), callbackContext)
-                "userLogout" -> userLogout()
+                "userLogout" -> userLogout(args.optBoolean(0, true))
                 "setLanguage" -> setLanguage(getStringFromJson(args.getString(0)))
                 "setLogLevel" -> setLogLevel(args.getInt(0))
                 "setThemeMode" -> setThemeMode(args.getInt(0))
@@ -144,8 +145,8 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 )
                 "restoreAllProducts" -> restoreAllProducts(callbackContext)
                 "silentRestoreAllProducts" -> restoreAllProducts(callbackContext)
-                "userSubscriptions" -> userSubscriptions(callbackContext)
-                "userSubscriptionsHistory" -> userSubscriptionsHistory(callbackContext)
+                "userSubscriptions" -> userSubscriptions(args.optBoolean(0, false), callbackContext)
+                "userSubscriptionsHistory" -> userSubscriptionsHistory(args.optBoolean(0, false), callbackContext)
                 "handleDeeplink" -> handleDeeplink(
                     getStringFromJson(args.getString(0)),
                     callbackContext
@@ -172,6 +173,7 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 "unregisterActionInterceptor" -> unregisterActionInterceptor(getStringFromJson(args.getString(0)))
                 "completeActionInterceptor" -> completeActionInterceptor(getStringFromJson(args.getString(0)), getStringFromJson(args.getString(1)))
                 "closePresentation" -> closePresentation(callbackContext)
+                "closeAllScreens" -> closePresentation(callbackContext)
                 "backPresentation" -> backPresentation(callbackContext)
                 "userDidConsumeSubscriptionContent" -> userDidConsumeSubscriptionContent()
                 "setUserAttributeWithString" -> setUserAttributeWithString(getStringFromJson(args.getString(0)), getStringFromJson(args.getString(1)), getStringFromJson(args.optString(2)))
@@ -184,13 +186,27 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 "setUserAttributeWithDoubleArray" -> setUserAttributeWithDoubleArray(getStringFromJson(args.getString(0)), args.getJSONArray(1), getStringFromJson(args.optString(2)))
                 "setUserAttributeWithBooleanArray" -> setUserAttributeWithBooleanArray(getStringFromJson(args.getString(0)), args.getJSONArray(1), getStringFromJson(args.optString(2)))
                 "userAttribute" -> userAttribute(getStringFromJson(args.getString(0)), callbackContext)
+                "userAttributes" -> userAttributes(callbackContext)
+                "incrementUserAttribute" -> incrementUserAttribute(getStringFromJson(args.getString(0)), args.optInt(1, 1))
+                "decrementUserAttribute" -> decrementUserAttribute(getStringFromJson(args.getString(0)), args.optInt(1, 1))
                 "clearUserAttribute" -> clearUserAttribute(getStringFromJson(args.getString(0)))
                 "clearUserAttributes" -> clearUserAttributes()
                 "clearBuiltInAttributes" -> clearBuiltInAttributes()
+                "getBuiltInAttributes" -> getBuiltInAttributes(callbackContext)
+                "getBuiltInAttribute" -> getBuiltInAttribute(getStringFromJson(args.getString(0)), callbackContext)
                 "isEligibleForIntroOffer" -> isEligibleForIntroOffer(getStringFromJson(args.getString(0)), callbackContext)
                 "signPromotionalOffer" -> signPromotionalOffer(getStringFromJson(args.getString(0)), getStringFromJson(args.getString(1)), callbackContext)
                 "revokeDataProcessingConsent" -> revokeDataProcessingConsent(args.getJSONArray(0))
                 "setDebugMode" -> setDebugMode(args.getBoolean(0))
+                "setDynamicOffering" -> setDynamicOffering(
+                    getStringFromJson(args.getString(0)),
+                    getStringFromJson(args.getString(1)),
+                    getStringFromJson(args.optString(2)),
+                    callbackContext
+                )
+                "getDynamicOfferings" -> getDynamicOfferings(callbackContext)
+                "removeDynamicOffering" -> removeDynamicOffering(getStringFromJson(args.getString(0)))
+                "clearDynamicOfferings" -> clearDynamicOfferings()
                 else -> return false
             }
         } catch (e: JSONException) {
@@ -371,6 +387,11 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         callbackContext.success(Purchasely.anonymousUserId)
     }
 
+    // REC-12 / PAR-04
+    private fun isAnonymous(callbackContext: CallbackContext) {
+        callbackContext.sendPluginResult(PluginResult(PluginResult.Status.OK, Purchasely.isAnonymous()))
+    }
+
     private fun userLogin(userId: String?, callbackContext: CallbackContext) {
         if(userId == null) {
             callbackContext.sendPluginResult(PluginResult(PluginResult.Status.OK, false))
@@ -382,8 +403,9 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         }
     }
 
-    private fun userLogout() {
-        Purchasely.userLogout(true)
+    // PAR-30: clearUserAttributes defaults to true (matches the JS-side default).
+    private fun userLogout(clearUserAttributes: Boolean) {
+        Purchasely.userLogout(clearUserAttributes)
     }
 
     private fun setLogLevel(logLevel: Int) {
@@ -438,6 +460,7 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
             CordovaPLYAttribute.moengageUniqueId.ordinal -> Attribute.MOENGAGE_UNIQUE_ID
             CordovaPLYAttribute.oneSignalExternalId.ordinal -> Attribute.ONESIGNAL_EXTERNAL_ID
             CordovaPLYAttribute.batchCustomUserId.ordinal -> Attribute.BATCH_CUSTOM_USER_ID
+            CordovaPLYAttribute.oneSignalUserId.ordinal -> Attribute.ONESIGNAL_USER_ID
             else -> null
         }
 
@@ -494,7 +517,6 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         transition: JSONObject?,
         callbackContext: CallbackContext
     ) {
-        purchaseCallback = callbackContext
         displayPresentation(
             screenId = presentationVendorId,
             placementId = null,
@@ -510,7 +532,6 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         transition: JSONObject?,
         callbackContext: CallbackContext
     ) {
-        purchaseCallback = callbackContext
         displayPresentation(
             screenId = null,
             placementId = placementVendorId,
@@ -526,7 +547,6 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         transition: JSONObject?,
         callbackContext: CallbackContext
     ) {
-        purchaseCallback = callbackContext
         displayPresentation(
             screenId = null,
             placementId = null,
@@ -554,7 +574,9 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                     contentId(contentId)
                     // v6: stream the presentation lifecycle to the JS callback via keep-alive
                     // envelopes; the dismiss outcome is delivered as the final (non-kept)
-                    // result by sendPurchaseResult.
+                    // result, resolved directly against this invocation's own callbackContext
+                    // (CDV-W-07: no shared/global callback slot, so overlapping present* calls
+                    // can never cross-wire, matching iOS's per-invocation closure capture).
                     onPresented { presentation, error ->
                         val env = mutableMapOf<String, Any?>("event" to "presented")
                         presentation?.let { env["presentation"] = presentationToMap(it) }
@@ -572,10 +594,9 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 val loaded = builder.build().preload()
                 displayedPresentation = loaded
                 loaded.display(cordova.activity, transitionFromMap(transition)) { outcome ->
-                    sendPurchaseResult(outcome)
+                    callbackContext.success(JSONObject(outcomeToMap(outcome)))
                 }
             } catch (t: Throwable) {
-                if (purchaseCallback === callbackContext) purchaseCallback = null
                 callbackContext.error(t.message ?: "Unable to present presentation")
             }
         }
@@ -625,16 +646,24 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
             return
         }
 
-        purchaseCallback = callbackContext
         displayedPresentation = loaded
 
         // TODO(v6-verify): loadingBackgroundColor cannot be applied to an already-preloaded
         // presentation in v6 (colors are builder options set before preload). The re-display
         // path delivers the dismiss outcome only; onPresented/onCloseRequested are wired on the
         // direct present* methods (builder-seeded before preload).
-        cordova.activity?.runOnUiThread {
-            loaded.display(cordova.activity, transitionFromMap(transition)) { outcome ->
-                sendPurchaseResult(outcome)
+        //
+        // CDV-W-07: resolve directly against this invocation's own callbackContext (no shared
+        // slot), and fail cleanly instead of silently no-op-ing when there's no activity to
+        // post to (the callback would otherwise never resolve).
+        val activity = cordova.activity
+        if (activity == null) {
+            callbackContext.error("No activity available to display presentation")
+            return
+        }
+        activity.runOnUiThread {
+            loaded.display(activity, transitionFromMap(transition)) { outcome ->
+                callbackContext.success(JSONObject(outcomeToMap(outcome)))
             }
         }
     }
@@ -701,10 +730,11 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         )
     }
 
-    private fun userSubscriptions(callbackContext: CallbackContext) {
+    // PAR-29: invalidateCache defaults to false (exposed from JS; was hardcoded true).
+    private fun userSubscriptions(invalidateCache: Boolean, callbackContext: CallbackContext) {
         launch {
             try {
-                val list = Purchasely.userSubscriptions(true)
+                val list = Purchasely.userSubscriptions(invalidateCache)
                 callbackContext.success(transformSubscriptionsToJson(list))
             } catch (e: Exception) {
                 callbackContext.error(e.message)
@@ -712,15 +742,37 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         }
     }
 
-    private fun userSubscriptionsHistory(callbackContext: CallbackContext) {
+    private fun userSubscriptionsHistory(invalidateCache: Boolean, callbackContext: CallbackContext) {
         launch {
             try {
-                val list = Purchasely.userSubscriptionsHistory(true)
+                val list = Purchasely.userSubscriptionsHistory(invalidateCache)
                 callbackContext.success(transformSubscriptionsToJson(list))
             } catch (e: Exception) {
                 callbackContext.error(e.message)
             }
         }
+    }
+
+    // Hardening for the upcoming rc.4 native release: PLYPlan.toMap()'s raw "type" entry is
+    // moving from an ordinal (Int) to the DistributionType name (String). transformPlanToMap
+    // already overwrites "type" explicitly wherever it's used, but allProducts/
+    // productWithIdentifier/the subscription's nested "product" field pass product.toMap()
+    // straight through -- normalize those raw plan entries so the JS PlanType contract
+    // (an ordinal) stays stable across both native formats. Both formats resolve to the same
+    // ordinal since DistributionType's declared order already matches Purchasely.PlanType.
+    private fun normalizePlanTypeOrdinal(raw: Any?): Int? = when (raw) {
+        is Number -> raw.toInt()
+        is String -> runCatching { DistributionType.valueOf(raw).ordinal }.getOrNull()
+        else -> null
+    }
+
+    private fun normalizeProductPlans(map: Map<String, Any?>): Map<String, Any?> {
+        val plans = map["plans"] as? List<*> ?: return map
+        val normalized = plans.map { plan ->
+            val planMap = plan as? Map<*, *> ?: return@map plan
+            HashMap(planMap).apply { this["type"] = normalizePlanTypeOrdinal(this["type"]) }
+        }
+        return HashMap(map).apply { this["plans"] = normalized }
     }
 
     private fun transformSubscriptionsToJson(list: List<PLYSubscriptionData>): JSONArray {
@@ -728,7 +780,7 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         for (data in list) {
             val map = HashMap(data.data.toMap())
             map["plan"] = transformPlanToMap(data.plan)
-            map["product"] = data.product.toMap()
+            map["product"] = normalizeProductPlans(data.product.toMap())
             map["subscriptionSource"] = when (data.data.storeType) {
                 StoreType.GOOGLE_PLAY_STORE -> StoreType.GOOGLE_PLAY_STORE.ordinal
                 StoreType.AMAZON_APP_STORE -> StoreType.AMAZON_APP_STORE.ordinal
@@ -764,7 +816,7 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 val list = Purchasely.allProducts()
                 val result = JSONArray()
                 for (product in list) {
-                    result.put(JSONObject(product.toMap()))
+                    result.put(JSONObject(normalizeProductPlans(product.toMap())))
                 }
                 callbackContext.success(result)
             } catch (e: Exception) {
@@ -782,7 +834,7 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
             try {
                 val product: PLYProduct? = Purchasely.product(vendorId)
                 if (product != null) {
-                    callbackContext.success(JSONObject(product.toMap()))
+                    callbackContext.success(JSONObject(normalizeProductPlans(product.toMap())))
                 } else {
                     callbackContext.error("No product found with $vendorId")
                 }
@@ -1090,6 +1142,26 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         }
     }
 
+    // REC-12 / PAR-03: bulk read, same per-value conversion as the single-key read above.
+    private fun userAttributes(callbackContext: CallbackContext) {
+        val result = JSONObject()
+        Purchasely.userAttributes().forEach { (key, value) ->
+            result.put(key, getUserAttributeValueForCordova(value))
+        }
+        callbackContext.success(result)
+    }
+
+    // REC-12 / PAR-02
+    private fun incrementUserAttribute(key: String?, value: Int) {
+        if (key == null) return
+        Purchasely.incrementUserAttribute(key, value)
+    }
+
+    private fun decrementUserAttribute(key: String?, value: Int) {
+        if (key == null) return
+        Purchasely.decrementUserAttribute(key, value)
+    }
+
     private fun getUserAttributeValueForCordova(value: Any?): Any? {
         return when (value) {
             is Date -> {
@@ -1134,6 +1206,33 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         Purchasely.clearBuiltInAttributes()
     }
 
+    // PAR-07
+    private fun getBuiltInAttributes(callbackContext: CallbackContext) {
+        val result = JSONObject()
+        Purchasely.getBuiltInAttributes().forEach { (key, value) ->
+            result.put(key, getUserAttributeValueForCordova(value))
+        }
+        callbackContext.success(result)
+    }
+
+    private fun getBuiltInAttribute(key: String?, callbackContext: CallbackContext) {
+        if (key == null) {
+            callbackContext.success()
+            return
+        }
+        val value = getUserAttributeValueForCordova(Purchasely.getBuiltInAttribute(key))
+        when (value) {
+            is JSONArray -> callbackContext.success(value)
+            is String -> callbackContext.success(value)
+            is Int -> callbackContext.success(value)
+            is Double -> callbackContext.sendPluginResult(PluginResult(PluginResult.Status.OK, value.toFloat()))
+            is Boolean -> callbackContext.sendPluginResult(PluginResult(PluginResult.Status.OK, value))
+            // No attribute for this key: resolve success with no value (undefined in JS),
+            // matching iOS's nullable id? return.
+            else -> callbackContext.success()
+        }
+    }
+
     private fun isEligibleForIntroOffer(planId: String?, callbackContext: CallbackContext) {
         launch {
             try {
@@ -1151,6 +1250,42 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
     // calling it unconditionally on both platforms doesn't have to special-case Android.
     private fun signPromotionalOffer(storeProductId: String?, storeOfferId: String?, callbackContext: CallbackContext) {
         callbackContext.success()
+    }
+
+    // PAR-05: Dynamic Offerings. Payload keys (reference/planVendorId/offerVendorId) match
+    // the Cordova JS↔native contract (not the native SDK's own reference/planId/offerId
+    // property names on PLYDynamicOffering).
+    private fun setDynamicOffering(reference: String?, planVendorId: String?, offerVendorId: String?, callbackContext: CallbackContext) {
+        if (reference == null || planVendorId == null) {
+            callbackContext.error("reference and planVendorId are required")
+            return
+        }
+        Purchasely.setDynamicOffering(reference, planVendorId, offerVendorId) { success ->
+            callbackContext.sendPluginResult(PluginResult(PluginResult.Status.OK, success))
+        }
+    }
+
+    private fun getDynamicOfferings(callbackContext: CallbackContext) {
+        Purchasely.getDynamicOfferings { offerings ->
+            val result = JSONArray()
+            offerings.forEach { offering ->
+                result.put(JSONObject(mapOf(
+                    "reference" to offering.reference,
+                    "planVendorId" to offering.planId,
+                    "offerVendorId" to offering.offerId
+                )))
+            }
+            callbackContext.success(result)
+        }
+    }
+
+    private fun removeDynamicOffering(reference: String?) {
+        if (reference == null) return
+        Purchasely.removeDynamicOffering(reference)
+    }
+
+    private fun clearDynamicOfferings() {
+        Purchasely.clearDynamicOfferings()
     }
 
     private fun revokeDataProcessingConsent(purposes: JSONArray?) {
@@ -1182,26 +1317,8 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
 
     companion object {
         var defaultCallback: CallbackContext? = null
-        var purchaseCallback: CallbackContext? = null
         var eventsCallback: CallbackContext? = null
         var attributesCallback: CallbackContext? = null
-
-        // Resolves a present*/presentPresentation call at dismissal. One-shot for the
-        // purchase callback; falls back to the (repeatable) default dismiss handler.
-        fun sendPurchaseResult(outcome: PLYPresentationOutcome) {
-            val json = JSONObject(outcomeToMap(outcome))
-            val oneShot = purchaseCallback
-            if (oneShot != null) {
-                oneShot.success(json)
-                purchaseCallback = null
-                return
-            }
-            defaultCallback?.let {
-                val pluginResult = PluginResult(PluginResult.Status.OK, json)
-                pluginResult.keepCallback = true
-                it.sendPluginResult(pluginResult)
-            }
-        }
 
         // Serializes a v6 PLYPresentationOutcome to the wire contract. `result` is kept as an
         // int (PurchaseResult 0/1/2) for back-compat with the pre-6.0 JS layer.
@@ -1270,7 +1387,8 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         }
     }
 
-    // WARNING: This enum must be strictly identical to the one in the JS side (Purchasely.js).
+    // WARNING: This enum must be strictly identical (same declaration order) to the one in
+    // the JS side (Purchasely.js) and iOS's CordovaPLYAttribute typedef.
     enum class CordovaPLYAttribute {
         firebase_app_instance_id,
         airship_channel_id,
@@ -1293,6 +1411,7 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
         moengageUniqueId,
         oneSignalExternalId,
         batchCustomUserId,
+        oneSignalUserId,
 
         /*
             FIREBASE_APP_INSTANCE_ID: 0,

--- a/purchasely/src/android/PurchaselyPlugin.kt
+++ b/purchasely/src/android/PurchaselyPlugin.kt
@@ -1327,7 +1327,7 @@ class PurchaselyPlugin : CordovaPlugin(), CoroutineScope {
                 result.put(JSONObject(mapOf(
                     "reference" to offering.reference,
                     "planVendorId" to offering.planId,
-                    "offerVendorId" to offering.offerId
+                    "offerVendorId" to (offering.offerId ?: JSONObject.NULL)
                 )))
             }
             callbackContext.success(result)

--- a/purchasely/src/ios/CDVPurchasely+Events.m
+++ b/purchasely/src/ios/CDVPurchasely+Events.m
@@ -13,7 +13,13 @@
 
 - (void)eventTriggered:(enum PLYEvent)event properties:(NSDictionary<NSString *, id> * _Nullable)properties {
 	if (self.eventCommand) {
-		NSDictionary<NSString *, id> *eventDict = @{@"name": [NSString fromPLYEvent:event], @"properties": properties};
+		// CDV-W-01: properties is _Nullable; inserting nil into an ObjC dictionary LITERAL
+		// throws NSInvalidArgumentException. Build it mutably and only set the key when non-nil.
+		NSMutableDictionary<NSString *, id> *eventDict = [NSMutableDictionary new];
+		[eventDict setObject:[NSString fromPLYEvent:event] forKey:@"name"];
+		if (properties != nil) {
+			[eventDict setObject:properties forKey:@"properties"];
+		}
 		CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:eventDict];
 
 		[pluginResult setKeepCallbackAsBool:YES];

--- a/purchasely/src/ios/CDVPurchasely.h
+++ b/purchasely/src/ios/CDVPurchasely.h
@@ -38,6 +38,7 @@
 - (void)userLogout:(CDVInvokedUrlCommand*)command;
 - (void)setAttribute:(CDVInvokedUrlCommand*)command;
 - (void)getAnonymousUserId:(CDVInvokedUrlCommand*)command;
+- (void)isAnonymous:(CDVInvokedUrlCommand*)command;
 - (void)allowDeeplink:(CDVInvokedUrlCommand*)command;
 - (void)allowCampaigns:(CDVInvokedUrlCommand*)command;
 - (void)handleDeeplink:(CDVInvokedUrlCommand*)command;
@@ -60,6 +61,7 @@
 - (void)unregisterActionInterceptor:(CDVInvokedUrlCommand*)command;
 - (void)completeActionInterceptor:(CDVInvokedUrlCommand*)command;
 - (void)closePresentation:(CDVInvokedUrlCommand*)command;
+- (void)closeAllScreens:(CDVInvokedUrlCommand*)command;
 - (void)backPresentation:(CDVInvokedUrlCommand*)command;
 - (void)userDidConsumeSubscriptionContent:(CDVInvokedUrlCommand*)command;
 - (void)setUserAttributeWithStringArray:(CDVInvokedUrlCommand*)command;
@@ -72,14 +74,23 @@
 - (void)setUserAttributeWithDouble:(CDVInvokedUrlCommand*)command;
 - (void)setUserAttributeWithDate:(CDVInvokedUrlCommand*)command;
 - (void)userAttribute:(CDVInvokedUrlCommand*)command;
+- (void)userAttributes:(CDVInvokedUrlCommand*)command;
+- (void)incrementUserAttribute:(CDVInvokedUrlCommand*)command;
+- (void)decrementUserAttribute:(CDVInvokedUrlCommand*)command;
 - (void)clearUserAttribute:(CDVInvokedUrlCommand*)command;
 - (void)clearUserAttributes:(CDVInvokedUrlCommand*)command;
 - (void)clearBuiltInAttributes:(CDVInvokedUrlCommand*)command;
+- (void)getBuiltInAttributes:(CDVInvokedUrlCommand*)command;
+- (void)getBuiltInAttribute:(CDVInvokedUrlCommand*)command;
 - (void)fetchPresentation:(CDVInvokedUrlCommand*)command;
 - (void)presentPresentation:(CDVInvokedUrlCommand*)command;
 - (void)signPromotionalOffer:(CDVInvokedUrlCommand*)command;
 - (void)isEligibleForIntroOffer:(CDVInvokedUrlCommand*)command;
 - (void)setThemeMode:(CDVInvokedUrlCommand*)command;
 - (void)addUserAttributeListener:(CDVInvokedUrlCommand*)command;
+- (void)setDynamicOffering:(CDVInvokedUrlCommand*)command;
+- (void)getDynamicOfferings:(CDVInvokedUrlCommand*)command;
+- (void)removeDynamicOffering:(CDVInvokedUrlCommand*)command;
+- (void)clearDynamicOfferings:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/purchasely/src/ios/CDVPurchasely.m
+++ b/purchasely/src/ios/CDVPurchasely.m
@@ -593,11 +593,14 @@
     if (![offerVendorId isKindOfClass:[NSString class]]) {
         offerVendorId = nil;
     }
+    // iOS 26.4+ Apple commitment billing plan type (0 unspecified / 1 upFront / 2 monthly);
+    // JS defaults it to unspecified when omitted (see Purchasely.BillingPlanType).
+    PLYBillingPlanType billingPlanType = [[command argumentAtIndex:3 withDefault:@(PLYBillingPlanTypeUnspecified)] integerValue];
 
     [Purchasely setDynamicOfferingWithReference:reference
                                     planVendorId:planVendorId
                                    offerVendorId:offerVendorId
-                                 billingPlanType:PLYBillingPlanTypeUnspecified
+                                 billingPlanType:billingPlanType
                                       completion:^(BOOL success) {
         [self successFor:command resultBool:success];
     }];

--- a/purchasely/src/ios/CDVPurchasely.m
+++ b/purchasely/src/ios/CDVPurchasely.m
@@ -122,7 +122,10 @@
 }
 
 - (void)userLogout:(CDVInvokedUrlCommand*)command {
-    [Purchasely userLogout:YES];
+    // PAR-30: clearUserAttributes defaults to true (matches the JS-side default).
+    NSNumber *clearUserAttributes = [command argumentAtIndex:0];
+    BOOL clear = [clearUserAttributes isKindOfClass:[NSNumber class]] ? clearUserAttributes.boolValue : YES;
+    [Purchasely userLogout:clear];
 }
 
 - (void)setThemeMode:(CDVInvokedUrlCommand *)command {
@@ -207,6 +210,9 @@
         case CordovaPLYAttributeBatchCustomUserId:
             attribute = PLYAttributeBatchCustomUserId;
             break;
+        case CordovaPLYAttributeOneSignalUserId:
+            attribute = PLYAttributeOneSignalUserId;
+            break;
         default:
             attributeFound = NO;
             break;
@@ -223,6 +229,11 @@
 - (void)getAnonymousUserId:(CDVInvokedUrlCommand*)command {
     NSString *anonymousId = [Purchasely anonymousUserId];
     [self successFor:command resultString:anonymousId];
+}
+
+// REC-12 / PAR-04
+- (void)isAnonymous:(CDVInvokedUrlCommand*)command {
+    [self successFor:command resultBool:[Purchasely isAnonymous]];
 }
 
 - (void)allowDeeplink:(CDVInvokedUrlCommand*)command {
@@ -466,7 +477,10 @@
 }
 
 - (void)userSubscriptions:(CDVInvokedUrlCommand*)command {
-    [Purchasely userSubscriptions:false
+    // PAR-29: invalidateCache defaults to false.
+    NSNumber *invalidateCache = [command argumentAtIndex:0];
+    BOOL invalidate = [invalidateCache isKindOfClass:[NSNumber class]] ? invalidateCache.boolValue : NO;
+    [Purchasely userSubscriptions:invalidate
                           success:^(NSArray<PLYSubscription *> * _Nullable subscriptions) {
         NSMutableArray *result = [NSMutableArray new];
         for (PLYSubscription *subscription in subscriptions) {
@@ -480,7 +494,10 @@
 }
 
 - (void)userSubscriptionsHistory:(CDVInvokedUrlCommand*)command {
-    [Purchasely userSubscriptionsHistory:false
+    // PAR-29: invalidateCache defaults to false.
+    NSNumber *invalidateCache = [command argumentAtIndex:0];
+    BOOL invalidate = [invalidateCache isKindOfClass:[NSNumber class]] ? invalidateCache.boolValue : NO;
+    [Purchasely userSubscriptionsHistory:invalidate
                           success:^(NSArray<PLYSubscription *> * _Nullable subscriptions) {
         NSMutableArray *result = [NSMutableArray new];
         for (PLYSubscription *subscription in subscriptions) {
@@ -565,6 +582,50 @@
     } failure:^(NSError * _Nullable error) {
         [self failureFor:command resultString:error.localizedDescription];
     }];
+}
+
+// PAR-05: Dynamic Offerings. Payload keys (reference/planVendorId/offerVendorId) match the
+// Cordova JS↔native contract (not the native SDK's own planId/offerId property names).
+- (void)setDynamicOffering:(CDVInvokedUrlCommand*)command {
+    NSString *reference = [command argumentAtIndex:0];
+    NSString *planVendorId = [command argumentAtIndex:1];
+    NSString *offerVendorId = [command argumentAtIndex:2];
+    if (![offerVendorId isKindOfClass:[NSString class]]) {
+        offerVendorId = nil;
+    }
+
+    [Purchasely setDynamicOfferingWithReference:reference
+                                    planVendorId:planVendorId
+                                   offerVendorId:offerVendorId
+                                 billingPlanType:PLYBillingPlanTypeUnspecified
+                                      completion:^(BOOL success) {
+        [self successFor:command resultBool:success];
+    }];
+}
+
+- (void)getDynamicOfferings:(CDVInvokedUrlCommand*)command {
+    [Purchasely getDynamicOfferingsWithCompletion:^(NSArray<PLYOffering *> * _Nonnull offerings) {
+        NSMutableArray *result = [NSMutableArray new];
+        for (PLYOffering *offering in offerings) {
+            NSMutableDictionary<NSString *, id> *dict = [NSMutableDictionary new];
+            dict[@"reference"] = offering.reference;
+            dict[@"planVendorId"] = offering.planId;
+            dict[@"offerVendorId"] = offering.offerId ?: [NSNull null];
+            [result addObject:dict];
+        }
+        [self successFor:command resultArray:result];
+    }];
+}
+
+- (void)removeDynamicOffering:(CDVInvokedUrlCommand*)command {
+    NSString *reference = [command argumentAtIndex:0];
+    if ([reference isKindOfClass:[NSString class]]) {
+        [Purchasely removeDynamicOfferingWithReference:reference];
+    }
+}
+
+- (void)clearDynamicOfferings:(CDVInvokedUrlCommand*)command {
+    [Purchasely clearDynamicOfferings];
 }
 
 // Helpers
@@ -904,10 +965,21 @@ static BOOL PLYPresentationActionFromString(NSString *kind, PLYPresentationActio
     completion(result);
 }
 
+// PAR-19: closeAllScreens is the canonical native action; closePresentation is kept as a
+// separate (deprecated, fire-and-forget) action since existing native `close` behavior is
+// preserved as-is, while closeAllScreens additionally reports success/error to JS.
 - (void)closePresentation:(CDVInvokedUrlCommand*)command {
     dispatch_async(dispatch_get_main_queue(), ^{
         [Purchasely closeAllScreens];
         self.currentPresentation = nil;
+    });
+}
+
+- (void)closeAllScreens:(CDVInvokedUrlCommand*)command {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [Purchasely closeAllScreens];
+        self.currentPresentation = nil;
+        [self successFor:command];
     });
 }
 
@@ -1084,6 +1156,34 @@ static BOOL PLYPresentationActionFromString(NSString *kind, PLYPresentationActio
     }
 }
 
+// REC-12 / PAR-03: bulk read, same per-value conversion as the single-key read above.
+- (void)userAttributes:(CDVInvokedUrlCommand*)command {
+    NSMutableDictionary<NSString *, id> *result = [NSMutableDictionary new];
+    NSDictionary<NSString *, id> *attributes = [Purchasely userAttributes];
+    for (NSString *key in attributes) {
+        id value = [self getUserAttributeValueForCordova:attributes[key]];
+        if (value != nil) {
+            result[key] = value;
+        }
+    }
+    [self successFor:command resultDict:result];
+}
+
+// REC-12 / PAR-02
+- (void)incrementUserAttribute:(CDVInvokedUrlCommand*)command {
+    NSString *key = [command argumentAtIndex:0];
+    NSNumber *valueNumber = [command argumentAtIndex:1];
+    NSInteger value = [valueNumber isKindOfClass:[NSNumber class]] ? valueNumber.integerValue : 1;
+    [Purchasely incrementUserAttributeWithKey:key value:value];
+}
+
+- (void)decrementUserAttribute:(CDVInvokedUrlCommand*)command {
+    NSString *key = [command argumentAtIndex:0];
+    NSNumber *valueNumber = [command argumentAtIndex:1];
+    NSInteger value = [valueNumber isKindOfClass:[NSNumber class]] ? valueNumber.integerValue : 1;
+    [Purchasely decrementUserAttributeWithKey:key value:value];
+}
+
 - (id _Nullable) getUserAttributeValueForCordova:(id _Nullable) value {
     if ([value isKindOfClass:[NSDate class]]) {
         NSDateFormatter * dateFormatter = [NSDateFormatter new];
@@ -1107,6 +1207,31 @@ static BOOL PLYPresentationActionFromString(NSString *kind, PLYPresentationActio
 
 - (void)clearBuiltInAttributes:(CDVInvokedUrlCommand*)command {
     [Purchasely clearBuiltInAttributes];
+}
+
+// PAR-07
+- (void)getBuiltInAttributes:(CDVInvokedUrlCommand*)command {
+    NSMutableDictionary<NSString *, id> *result = [NSMutableDictionary new];
+    NSDictionary<NSString *, id> *attributes = [Purchasely getBuiltInAttributes];
+    for (NSString *key in attributes) {
+        id value = [self getUserAttributeValueForCordova:attributes[key]];
+        if (value != nil) {
+            result[key] = value;
+        }
+    }
+    [self successFor:command resultDict:result];
+}
+
+- (void)getBuiltInAttribute:(CDVInvokedUrlCommand*)command {
+    NSString *key = [command argumentAtIndex:0];
+    id _Nullable result = [self getUserAttributeValueForCordova:[Purchasely getBuiltInAttributeWith:key]];
+    if (result != nil) {
+        [self successFor:command resultDict:result];
+    } else {
+        // No attribute for this key: resolve success with no value (undefined in JS),
+        // matching Android's nullable Any? return.
+        [self successFor:command];
+    }
 }
 
 - (void)fetchPresentation:(CDVInvokedUrlCommand*)command {
@@ -1430,7 +1555,8 @@ static BOOL PLYPresentationActionFromString(NSString *kind, PLYPresentationActio
 }
 
 
-// WARNING: This enum must be strictly identical to the one in the JS side (Purchasely.js).
+// WARNING: This enum must be strictly identical (same declaration order) to the one in
+// the JS side (Purchasely.js) and Android's CordovaPLYAttribute enum class.
 typedef NS_ENUM(NSInteger, CordovaPLYAttribute) {
     CordovaPLYAttributeFirebaseAppInstanceId,
     CordovaPLYAttributeAirshipChannelId,
@@ -1452,7 +1578,8 @@ typedef NS_ENUM(NSInteger, CordovaPLYAttribute) {
     CordovaPLYAttributeAmplitudeDeviceId,
     CordovaPLYAttributeMoengageUniqueId,
     CordovaPLYAttributeOneSignalExternalId,
-    CordovaPLYAttributeBatchCustomUserId
+    CordovaPLYAttributeBatchCustomUserId,
+    CordovaPLYAttributeOneSignalUserId
 };
 
 @end

--- a/purchasely/src/ios/CDVPurchasely.m
+++ b/purchasely/src/ios/CDVPurchasely.m
@@ -110,6 +110,12 @@
 
 - (void)userLogin:(CDVInvokedUrlCommand*)command {
     NSString *userId = [command argumentAtIndex:0];
+    // CDV-W-08: userLoginWith:appUserId: is _Nonnull; align with Android's guard instead of
+    // forwarding nil into the native call.
+    if (![userId isKindOfClass:[NSString class]]) {
+        [self successFor:command resultBool:NO];
+        return;
+    }
     [Purchasely userLoginWith:userId shouldRefresh:^(BOOL refresh) {
         [self successFor:command resultBool:refresh];
     }];
@@ -408,6 +414,11 @@
 
 - (void)purchasedSubscription:(CDVInvokedUrlCommand*)command {
     self.purchasedCommand = command;
+    // CDV-W-14: a repeat JS call (re-subscribe/hot reload) must not stack observers, or a
+    // single purchase/restoration fires reloadContent: once per accumulated registration.
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                     name: @"ply_purchasedSubscription"
+                                                   object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(reloadContent:)
                                                  name: @"ply_purchasedSubscription"
@@ -530,7 +541,10 @@
         if (@available(iOS 12.2, *)) {
             [Purchasely signPromotionalOfferWithStoreProductId:storeProductId storeOfferId:storeOfferId success:^(PLYOfferSignature * _Nonnull signature) {
                 NSDictionary* result = [self resultSignatureForSignPromoOffer:signature];
-                [self successFor:command resultBool:result];
+                // CDV-W-02: was resultBool: (an NSDictionary implicitly truncated to a bare
+                // BOOL), discarding the whole signature payload. resultDict: is the matching
+                // overload (declared below) for this NSDictionary result.
+                [self successFor:command resultDict:result];
             } failure:^(NSError * _Nullable error) {
                 [self failureFor:command resultString:error.localizedDescription];
             }];
@@ -1270,7 +1284,12 @@ static BOOL PLYPresentationActionFromString(NSString *kind, PLYPresentationActio
     if (presentation != nil) {
 
         if (presentation.screenId != nil) {
+            // CDV-W-03: `id` is kept for compatibility (and because findPresentationLoadedFor:/
+            // findIndexPresentationLoadedFor: key their re-display lookup on it); `screenId` is
+            // added to match Android's presentationToMap() key so shared JS can read either
+            // platform consistently.
             [presentationResult setObject:presentation.screenId forKey:@"id"];
+            [presentationResult setObject:presentation.screenId forKey:@"screenId"];
         }
 
         if (presentation.placementId != nil) {

--- a/purchasely/src/ios/CDVPurchasely.m
+++ b/purchasely/src/ios/CDVPurchasely.m
@@ -1409,10 +1409,13 @@ static BOOL PLYPresentationActionFromString(NSString *kind, PLYPresentationActio
     if (presentation != nil) {
 
         if (presentation.screenId != nil) {
-            // CDV-W-03: `id` is kept for compatibility (and because findPresentationLoadedFor:/
-            // findIndexPresentationLoadedFor: key their re-display lookup on it); `screenId` is
-            // added to match Android's presentationToMap() key so shared JS can read either
-            // platform consistently.
+            // `screenId` is the sole authoritative, public presentation identifier (matches
+            // Android's presentationToMap() key, so shared JS reads either platform the same
+            // way). `id` is kept ONLY as a private/internal re-display lookup key --
+            // findPresentationLoadedFor:/findIndexPresentationLoadedFor: key off it, and on
+            // this platform it always equals screenId (iOS has no separate synthetic fetch
+            // handle, unlike Android's `fetchId`) -- it is NOT a documented public field; the
+            // JS bridge normalizes with `screenId ?? id` tolerance and never surfaces `id`.
             [presentationResult setObject:presentation.screenId forKey:@"id"];
             [presentationResult setObject:presentation.screenId forKey:@"screenId"];
         }

--- a/purchasely/src/ios/Hybrid/PLYPlan+Hybrid.m
+++ b/purchasely/src/ios/Hybrid/PLYPlan+Hybrid.m
@@ -79,6 +79,25 @@
 		[dict setObject:introPeriod forKey:@"introPeriod"];
 	}
 
+	// Commitment installment details (iOS 26.4+ multi-period commitments, e.g. "monthly
+	// subscription with 12-month commitment"). Apple-only: the array is empty for every other
+	// plan, so the key is omitted then. Mirrors PLYPlan.commitmentInfo: [PLYCommitmentInfo].
+	NSArray<PLYCommitmentInfo *> *commitmentInfo = self.commitmentInfo;
+	if (commitmentInfo.count > 0) {
+		NSMutableArray<NSDictionary *> *commitmentArray = [NSMutableArray new];
+		for (PLYCommitmentInfo *info in commitmentInfo) {
+			[commitmentArray addObject:@{
+				@"billingPlanType": @(info.billingPlanType),
+				@"billingPrice":    info.billingPrice,
+				@"billingPeriod":   info.billingPeriod,
+				@"totalPrice":      info.totalPrice,
+				@"totalPeriod":     info.totalPeriod,
+				@"totalDuration":   @(info.totalDuration)
+			}];
+		}
+		[dict setObject:commitmentArray forKey:@"commitmentInfo"];
+	}
+
 	return dict;
 }
 

--- a/purchasely/src/ios/Hybrid/PLYSubscription+Hybrid.m
+++ b/purchasely/src/ios/Hybrid/PLYSubscription+Hybrid.m
@@ -28,6 +28,19 @@
 		[dict setObject:[dateFormat stringFromDate:self.cancelledDate] forKey:@"cancelledDate"];
 	}
 
+	// Commitment progress (iOS 26.4+ monthly commitment, e.g. billing period 3 of 12).
+	// Apple-only and nil for every non-committed subscription, so the key is omitted then.
+	// Mirrors PLYSubscription.commitmentProgress: PLYCommitmentProgress?
+	PLYCommitmentProgress *commitmentProgress = self.commitmentProgress;
+	if (commitmentProgress != nil) {
+		[dict setObject:@{
+			@"billingPeriodNumber":   @(commitmentProgress.billingPeriodNumber),
+			@"totalBillingPeriods":   @(commitmentProgress.totalBillingPeriods),
+			@"commitmentExpiresDate": [dateFormat stringFromDate:commitmentProgress.commitmentExpiresDate],
+			@"commitmentPrice":       commitmentProgress.commitmentPrice
+		} forKey:@"commitmentProgress"];
+	}
+
 	return dict;
 }
 

--- a/purchasely/www/Purchasely.js
+++ b/purchasely/www/Purchasely.js
@@ -565,8 +565,27 @@ exports.isAnonymous = function (success, error) {
 
 // PAR-05: Dynamic Offerings -- force a specific plan (and optionally offer) to be shown
 // in a specific context, keyed by an app-chosen reference.
-exports.setDynamicOffering = function (reference, planVendorId, offerVendorId, success, error) {
-    exec(success || (() => {}), error || defaultError, 'Purchasely', 'setDynamicOffering', [reference, planVendorId, offerVendorId]);
+// Purchasely 6.0 (iOS 26.4+, Apple only): billing plan type of a subscription with a
+// multi-period commitment (e.g. "monthly subscription with 12-month commitment"). Passed to
+// setDynamicOffering and surfaced on the commitment fields below. Android always reports
+// `unspecified`.
+exports.BillingPlanType = { unspecified: 0, upFront: 1, monthly: 2 };
+
+// Purchasely 6.0 commitment fields (iOS 26.4+ only; absent on Android and on plans without a
+// commitment):
+//  - A plan object (from allProducts()/planWithIdentifier(), a presentation outcome's `plan`,
+//    and the interceptAction('purchase') `parameters.plan`) may carry `commitmentInfo`: an
+//    array of { billingPlanType (Number, see Purchasely.BillingPlanType), billingPrice
+//    (Number), billingPeriod (ISO 8601 duration string, e.g. "P1M"), totalPrice (Number),
+//    totalPeriod (ISO 8601 duration string, e.g. "P1Y"), totalDuration (Number of billing
+//    cycles) }.
+//  - A subscription object (from userSubscriptions()/userSubscriptionsHistory()) may carry
+//    `commitmentProgress`: { billingPeriodNumber (Number), totalBillingPeriods (Number),
+//    commitmentExpiresDate (ISO 8601 date string), commitmentPrice (Number) }.
+exports.setDynamicOffering = function (reference, planVendorId, offerVendorId, billingPlanType, success, error) {
+    exec(success || (() => {}), error || defaultError, 'Purchasely', 'setDynamicOffering',
+        [reference, planVendorId, offerVendorId != null ? offerVendorId : null,
+         billingPlanType != null ? billingPlanType : 0]);
 };
 
 // Returns a list of { reference, planVendorId, offerVendorId }.

--- a/purchasely/www/Purchasely.js
+++ b/purchasely/www/Purchasely.js
@@ -153,9 +153,11 @@ exports.synchronize = function (success, error) {
 //
 //   Purchasely.presentation.placement(id) | .screen(id) | .defaultSource()  // alias: .default()
 //     .contentId(id)
+//     .backgroundColor(hex)
 //     .onPresented(cb) / .onCloseRequested(cb) / .onDismissed(cb)
 //     .build()
-//       .preload()             -> Promise<presentation>            (screenId is authoritative)
+//       .preload()             -> Promise<loadedPresentation>      (screenId is authoritative;
+//                                  the resolved object also exposes display()/close()/back())
 //       .display(transition?)  -> Promise<outcome>                 ({ presentation, purchaseResult, plan, closeReason, error })
 //       .close()               -> closeAllScreens()
 //       .back()                -> navigate back within the displayed presentation
@@ -166,6 +168,16 @@ exports.synchronize = function (success, error) {
 // which already equals screenId there) never leaves the private `_raw` field
 // kept on the request -- it is not part of the presentation object handed back
 // to callers.
+//
+// Modifier parity note: .backgroundColor(hex) is the ONLY presentation-style
+// modifier the Cordova native layer actually supports -- it is wired to
+// presentPresentation's native backgroundColor argument (preload -> display
+// re-display path) and merged into the transition object for the direct present*
+// paths (iOS reads transition.backgroundColor). It sets the loading/background
+// color and takes effect on iOS; on Android it only applies through drawer/popin
+// transitions (native limitation). The RN/Flutter builder's progressColor,
+// displayCloseButton and displayBackButton are intentionally NOT exposed here: no
+// Cordova native present action accepts them.
 
 function normalizeError(error) {
     if (error === undefined || error === null) return null;
@@ -221,7 +233,14 @@ PLYPresentationRequest.prototype.preload = function () {
     return new Promise(function (resolve, reject) {
         exec(function (raw) {
             self._raw = raw;
-            resolve(normalizePresentation(raw));
+            // Resolve a "loaded presentation": the screenId-normalized data plus
+            // display()/close()/back() delegating to this request (parity with RN's
+            // PLYLoadedPresentation and the native preload()->display() flow).
+            resolve(Object.assign({}, normalizePresentation(raw), {
+                display: function (transition) { return self.display(transition); },
+                close: function () { return self.close(); },
+                back: function () { return self.back(); }
+            }));
         }, function (error) {
             reject(normalizeError(error));
         }, 'Purchasely', 'fetchPresentation', [
@@ -236,6 +255,14 @@ PLYPresentationRequest.prototype.display = function (transition) {
     var self = this;
     var callbacks = this._config.callbacks;
     var normalizedTransition = normalizeTransition(transition);
+    // .backgroundColor() sugar: merge into the transition object so the direct
+    // present* paths (iOS reads transition.backgroundColor) pick it up. The
+    // transition's own backgroundColor, if any, still wins. Keeping no `type`
+    // when none was given preserves CDV-W-12 (backend default honored).
+    if (self._config.backgroundColor != null) {
+        normalizedTransition = Object.assign({ backgroundColor: self._config.backgroundColor }, normalizedTransition || {});
+    }
+    var backgroundColor = self._config.backgroundColor != null ? self._config.backgroundColor : null;
 
     return new Promise(function (resolve) {
         function settle(rawOutcome) {
@@ -255,7 +282,7 @@ PLYPresentationRequest.prototype.display = function (transition) {
         if (self._raw) {
             // Re-display the presentation preloaded by preload() -- same native
             // 'presentPresentation' action v5 used, carrying its private handle.
-            exec(dispatch, onNativeError, 'Purchasely', 'presentPresentation', [self._raw, normalizedTransition, null]);
+            exec(dispatch, onNativeError, 'Purchasely', 'presentPresentation', [self._raw, normalizedTransition, backgroundColor]);
         } else if (self._config.screenId) {
             exec(dispatch, onNativeError, 'Purchasely', 'presentPresentationWithIdentifier',
                 [self._config.screenId, self._config.contentId || null, normalizedTransition]);
@@ -288,6 +315,14 @@ function PLYPresentationBuilder(config) {
 
 PLYPresentationBuilder.prototype.contentId = function (id) {
     this._config.contentId = id;
+    return this;
+};
+
+// Loading/background color (hex). See the modifier parity note above: this is the
+// only style modifier the Cordova native layer supports; progressColor /
+// displayCloseButton / displayBackButton are intentionally not exposed.
+PLYPresentationBuilder.prototype.backgroundColor = function (hex) {
+    this._config.backgroundColor = hex;
     return this;
 };
 

--- a/purchasely/www/Purchasely.js
+++ b/purchasely/www/Purchasely.js
@@ -20,16 +20,20 @@ function normalizeTransition(mode) {
     return undefined;
 }
 
-// Wire a present* command's callback stream. Purchasely 6.0 emits presentation
-// lifecycle events during display: the native side sends keep-alive envelopes
-// { event: 'presented', presentation } and { event: 'closeRequested' }, then the
+// Wire a present* command's callback stream -- used identically for the direct present*
+// actions and for the preload() -> display() re-display path (native `presentPresentation`),
+// so both surface the same lifecycle regardless of how display() was reached. Purchasely 6.0
+// emits presentation lifecycle events during display: the native side sends keep-alive
+// envelopes { event: 'presented', presentation } and { event: 'closeRequested' }, then the
 // dismiss OUTCOME (which has no `event` key) as the final, non-kept callback.
-// `callbacks` may carry onPresented(presentation, error) and onCloseRequested().
+// `callbacks` may carry onPresented(presentation, error) and onCloseRequested(). The
+// 'presented' envelope's presentation is screenId-normalized like everywhere else (preload(),
+// outcome.presentation) -- never the raw native payload.
 function presentationDispatcher(success, callbacks) {
     callbacks = callbacks || {};
     return function (payload) {
         if (payload && payload.event === 'presented') {
-            if (callbacks.onPresented) callbacks.onPresented(payload.presentation || null, payload.error || null);
+            if (callbacks.onPresented) callbacks.onPresented(normalizePresentation(payload.presentation), payload.error || null);
             return;
         }
         if (payload && payload.event === 'closeRequested') {

--- a/purchasely/www/Purchasely.js
+++ b/purchasely/www/Purchasely.js
@@ -8,13 +8,16 @@ var defaultError = (e) => { console.log(e); }
 //   - a full transition object { type, dismissible?, width?, height?, backgroundColor? }
 //     where width/height are { type: 'pixel'|'percentage', value: Number } (width is
 //     popin-only, height drives drawer+popin) and backgroundColor is a hex string.
-// Always returns a transition object for the native bridge.
+// CDV-W-12: when no displayMode is given, sends undefined (not a forced fullScreen
+// default) so both natives' nil/null handling honors the backend-configured transition
+// for that placement/screen, as documented in their own displayModeFromTransition /
+// transitionFromMap helpers.
 function normalizeTransition(mode) {
     if (mode === true) return { type: 'fullScreen' };
     if (mode === false) return { type: 'modal' };
     if (typeof mode === 'string') return { type: mode };
     if (mode && typeof mode === 'object' && mode.type) return mode;
-    return { type: 'fullScreen' };
+    return undefined;
 }
 
 // Wire a present* command's callback stream. Purchasely 6.0 emits presentation
@@ -62,6 +65,14 @@ exports.start = function (options, success, error) {
     exec(success, error, 'Purchasely', 'start', [opts]);
 };
 
+// REC-18 / PAR-18: addEventListener is the canonical name (matches RN's naming).
+// addEventsListener (plural "Events", the original Cordova-only spelling) is kept as a
+// deprecated alias.
+exports.addEventListener = function (success, error) {
+    exec(success, error, 'Purchasely', 'addEventsListener', []);
+};
+
+// @deprecated use addEventListener instead.
 exports.addEventsListener = function (success, error) {
     exec(success, error, 'Purchasely', 'addEventsListener', []);
 };
@@ -74,6 +85,12 @@ exports.removeUserAttributeListener = function () {
     exec(() => {}, defaultError, 'Purchasely', 'removeUserAttributeListener', []);
 };
 
+// REC-18 / PAR-18: canonical name, paired with addEventListener.
+exports.removeEventListener = function () {
+    exec(() => {}, defaultError, 'Purchasely', 'removeEventsListener', []);
+};
+
+// @deprecated use removeEventListener instead.
 exports.removeEventsListener = function () {
     exec(() => {}, defaultError, 'Purchasely', 'removeEventsListener', []);
 };
@@ -86,8 +103,11 @@ exports.userLogin = function (userId, success) {
     exec(success, defaultError, 'Purchasely', 'userLogin', [userId]);
 };
 
-exports.userLogout = function () {
-    exec(() => {}, defaultError, 'Purchasely', 'userLogout', []);
+// PAR-30: clearUserAttributes controls whether logout also clears locally cached user
+// attributes (native default true on both platforms).
+exports.userLogout = function (clearUserAttributes) {
+    var clear = clearUserAttributes === undefined ? true : clearUserAttributes;
+    exec(() => {}, defaultError, 'Purchasely', 'userLogout', [clear]);
 };
 
 exports.setLogLevel = function (logLevel) {
@@ -244,21 +264,30 @@ exports.userDidConsumeSubscriptionContent = function () {
     exec(() => {}, defaultError, 'Purchasely', 'userDidConsumeSubscriptionContent', []);
 };
 
-exports.userSubscriptions = function (success, error) {
-    exec(success, defaultError, 'Purchasely', 'userSubscriptions', []);
+// PAR-29: invalidateCache forces a fresh fetch instead of returning the cached list
+// (native default false on both platforms).
+exports.userSubscriptions = function (success, error, invalidateCache) {
+    exec(success, defaultError, 'Purchasely', 'userSubscriptions', [!!invalidateCache]);
 };
 
-exports.userSubscriptionsHistory = function (success, error) {
-    exec(success, defaultError, 'Purchasely', 'userSubscriptionsHistory', []);
+exports.userSubscriptionsHistory = function (success, error, invalidateCache) {
+    exec(success, defaultError, 'Purchasely', 'userSubscriptionsHistory', [!!invalidateCache]);
 };
 
 exports.setLanguage = function (language) {
     exec(() => {}, defaultError, 'Purchasely', 'setLanguage', [language]);
 };
 
-// Purchasely 6.0: close the displayed presentation.
-exports.closePresentation = function () {
-    exec(() => {}, defaultError, 'Purchasely', 'closePresentation', []);
+// PAR-19: closeAllScreens is the canonical name (matches the iOS/Android Purchasely-level
+// API). success/error are optional.
+exports.closeAllScreens = function (success, error) {
+    exec(success || (() => {}), error || defaultError, 'Purchasely', 'closeAllScreens', []);
+};
+
+// @deprecated use closeAllScreens instead; kept as an alias (same native action both
+// platforms already call: Purchasely.closeAllScreens()).
+exports.closePresentation = function (success, error) {
+    exports.closeAllScreens(success, error);
 };
 
 // Purchasely 6.0: navigate back within the displayed presentation.
@@ -306,6 +335,22 @@ exports.userAttribute = function (key, success, error) {
     exec(success, error, 'Purchasely', 'userAttribute', [key]);
 };
 
+// REC-12 / PAR-03: bulk read of every user attribute currently stored, with the same
+// per-value type conversions as the single-key userAttribute(key) read.
+exports.userAttributes = function (success, error) {
+    exec(success, error || defaultError, 'Purchasely', 'userAttributes', []);
+};
+
+// REC-12 / PAR-02: increment/decrement a numerical user attribute. value defaults to 1
+// natively when omitted.
+exports.incrementUserAttribute = function (key, value) {
+    exec(() => {}, defaultError, 'Purchasely', 'incrementUserAttribute', [key, value]);
+};
+
+exports.decrementUserAttribute = function (key, value) {
+    exec(() => {}, defaultError, 'Purchasely', 'decrementUserAttribute', [key, value]);
+};
+
 exports.clearUserAttribute = function (key) {
     exec(() => {}, defaultError, 'Purchasely', 'clearUserAttribute', [key]);
 };
@@ -318,10 +363,45 @@ exports.clearBuiltInAttributes = function () {
     exec(() => {}, defaultError, 'Purchasely', 'clearBuiltInAttributes', []);
 }
 
+// PAR-07: read-only accessors for the built-in (SDK-collected) attributes.
+exports.getBuiltInAttributes = function (success, error) {
+    exec(success, error || defaultError, 'Purchasely', 'getBuiltInAttributes', []);
+};
+
+exports.getBuiltInAttribute = function (key, success, error) {
+    exec(success, error || defaultError, 'Purchasely', 'getBuiltInAttribute', [key]);
+};
+
+// REC-12 / PAR-04: whether the current user is anonymous (no userLogin call yet).
+exports.isAnonymous = function (success, error) {
+    exec(success, error || defaultError, 'Purchasely', 'isAnonymous', []);
+};
+
+// PAR-05: Dynamic Offerings -- force a specific plan (and optionally offer) to be shown
+// in a specific context, keyed by an app-chosen reference.
+exports.setDynamicOffering = function (reference, planVendorId, offerVendorId, success, error) {
+    exec(success || (() => {}), error || defaultError, 'Purchasely', 'setDynamicOffering', [reference, planVendorId, offerVendorId]);
+};
+
+// Returns a list of { reference, planVendorId, offerVendorId }.
+exports.getDynamicOfferings = function (success, error) {
+    exec(success, error || defaultError, 'Purchasely', 'getDynamicOfferings', []);
+};
+
+exports.removeDynamicOffering = function (reference) {
+    exec(() => {}, defaultError, 'Purchasely', 'removeDynamicOffering', [reference]);
+};
+
+exports.clearDynamicOfferings = function () {
+    exec(() => {}, defaultError, 'Purchasely', 'clearDynamicOfferings', []);
+};
+
 exports.isEligibleForIntroOffer = function (planId, success, error) {
     exec(success, error, 'Purchasely', 'isEligibleForIntroOffer', [planId]);
 };
 
+// REC-04: iOS-only (StoreKit promotional offer signing). On Android this is a no-op that
+// resolves success (no signing is required there); no error is raised.
 exports.signPromotionalOffer = function (storeProductId, storeOfferId, success, error) {
     exec(success, error, 'Purchasely', 'signPromotionalOffer', [storeProductId, storeOfferId]);
 };
@@ -367,6 +447,10 @@ exports.Attribute = {
   MOENGAGE_UNIQUE_ID: 18,
   ONESIGNAL_EXTERNAL_ID: 19,
   BATCH_CUSTOM_USER_ID: 20,
+  // ENM-02 / REC-11: keep this list, iOS's CordovaPLYAttribute, and Android's
+  // CordovaPLYAttribute enum class in strictly identical declaration order -- the bridge
+  // matches by ordinal/symbol position, not by real native raw value.
+  ONESIGNAL_USER_ID: 21,
 }
 
 exports.DataProcessingLegalBasis = {

--- a/purchasely/www/Purchasely.js
+++ b/purchasely/www/Purchasely.js
@@ -143,39 +143,191 @@ exports.synchronize = function (success, error) {
     exec(success || (() => {}), error || defaultError, 'Purchasely', 'synchronize', []);
 };
 
-// present* methods: `displayMode` accepts a mode string, a legacy boolean, or a
-// full transition object (see normalizeTransition). `callbacks` is optional and
-// may carry { onPresented(presentation, error), onCloseRequested() }; `success`
-// still receives the final dismiss outcome.
-exports.presentPresentationWithIdentifier = function (presentationId, contentId, displayMode, success, error, callbacks) {
-    exec(presentationDispatcher(success, callbacks), error, 'Purchasely', 'presentPresentationWithIdentifier', [presentationId, contentId, normalizeTransition(displayMode)]);
+// Purchasely 6.0: the v5 presentation surface (fetchPresentation*, present-
+// Presentation*, presentPresentation, backPresentation) is REMOVED, not
+// deprecated -- replaced by the v6 builder below (parity with the React
+// Native/Flutter SDKs; see MIGRATION-v6.md). It re-wraps the very same native
+// exec actions used by v5 (fetchPresentation, presentPresentation,
+// presentPresentationWithIdentifier/ForPlacement/ForDefault, backPresentation,
+// closeAllScreens): no new native action is introduced.
+//
+//   Purchasely.presentation.placement(id) | .screen(id) | .defaultSource()  // alias: .default()
+//     .contentId(id)
+//     .onPresented(cb) / .onCloseRequested(cb) / .onDismissed(cb)
+//     .build()
+//       .preload()             -> Promise<presentation>            (screenId is authoritative)
+//       .display(transition?)  -> Promise<outcome>                 ({ presentation, purchaseResult, plan, closeReason, error })
+//       .close()               -> closeAllScreens()
+//       .back()                -> navigate back within the displayed presentation
+//
+// screenId is authoritative: normalizePresentation always resolves it (tolerating
+// a raw `id` fallback) and only exposes the documented presentation fields. Any
+// native re-display handle (Android's synthetic fetchId; iOS's internal `id`,
+// which already equals screenId there) never leaves the private `_raw` field
+// kept on the request -- it is not part of the presentation object handed back
+// to callers.
+
+function normalizeError(error) {
+    if (error === undefined || error === null) return null;
+    if (typeof error === 'object' && error.message) return error;
+    return { message: String(error) };
+}
+
+function normalizePresentation(raw) {
+    if (!raw || typeof raw !== 'object') return null;
+    var screenId = raw.screenId != null ? raw.screenId : raw.id;
+    if (screenId == null) return null;
+    return {
+        screenId: screenId,
+        placementId: raw.placementId != null ? raw.placementId : null,
+        contentId: raw.contentId != null ? raw.contentId : null,
+        audienceId: raw.audienceId != null ? raw.audienceId : null,
+        abTestId: raw.abTestId != null ? raw.abTestId : null,
+        abTestVariantId: raw.abTestVariantId != null ? raw.abTestVariantId : null,
+        campaignId: raw.campaignId != null ? raw.campaignId : null,
+        flowId: raw.flowId != null ? raw.flowId : null,
+        language: raw.language != null ? raw.language : null,
+        type: raw.type != null ? raw.type : null,
+        plans: raw.plans != null ? raw.plans : null,
+        metadata: raw.metadata != null ? raw.metadata : null,
+        height: raw.height != null ? raw.height : null
+    };
+}
+
+function normalizeOutcome(raw) {
+    raw = raw || {};
+    return {
+        presentation: normalizePresentation(raw.presentation),
+        purchaseResult: raw.purchaseResult != null ? raw.purchaseResult : null,
+        plan: raw.plan != null ? raw.plan : null,
+        closeReason: raw.closeReason != null ? raw.closeReason : null,
+        error: raw.error != null ? raw.error : null
+    };
+}
+
+// A single presentation request: preload it (fetch without display), display it
+// (resolves at dismiss with a 5-field outcome), close it, or navigate back. Calling
+// `display()` after `preload()` re-displays the exact presentation that was fetched
+// (via the native presentPresentation action, carrying its private re-display
+// handle); `display()` alone (no prior preload) fetches and displays directly
+// through the present* action matching this request's source.
+function PLYPresentationRequest(config) {
+    this._config = config; // { placementId?, screenId?, contentId?, callbacks }
+    this._raw = null; // private: native fetch payload (carries the re-display handle)
+}
+
+PLYPresentationRequest.prototype.preload = function () {
+    var self = this;
+    return new Promise(function (resolve, reject) {
+        exec(function (raw) {
+            self._raw = raw;
+            resolve(normalizePresentation(raw));
+        }, function (error) {
+            reject(normalizeError(error));
+        }, 'Purchasely', 'fetchPresentation', [
+            self._config.placementId || null,
+            self._config.screenId || null,
+            self._config.contentId || null
+        ]);
+    });
 };
 
-exports.presentPresentationForPlacement = function (placementId, contentId, displayMode, success, error, callbacks) {
-    exec(presentationDispatcher(success, callbacks), error, 'Purchasely', 'presentPresentationForPlacement', [placementId, contentId, normalizeTransition(displayMode)]);
+PLYPresentationRequest.prototype.display = function (transition) {
+    var self = this;
+    var callbacks = this._config.callbacks;
+    var normalizedTransition = normalizeTransition(transition);
+
+    return new Promise(function (resolve) {
+        function settle(rawOutcome) {
+            var outcome = normalizeOutcome(rawOutcome);
+            if (callbacks.onDismissed) callbacks.onDismissed(outcome);
+            resolve(outcome);
+        }
+        var dispatch = presentationDispatcher(settle, {
+            onPresented: callbacks.onPresented,
+            onCloseRequested: callbacks.onCloseRequested
+        });
+        function onNativeError(error) {
+            var normalized = normalizeError(error);
+            settle({ error: normalized ? normalized.message : 'Unable to display presentation' });
+        }
+
+        if (self._raw) {
+            // Re-display the presentation preloaded by preload() -- same native
+            // 'presentPresentation' action v5 used, carrying its private handle.
+            exec(dispatch, onNativeError, 'Purchasely', 'presentPresentation', [self._raw, normalizedTransition, null]);
+        } else if (self._config.screenId) {
+            exec(dispatch, onNativeError, 'Purchasely', 'presentPresentationWithIdentifier',
+                [self._config.screenId, self._config.contentId || null, normalizedTransition]);
+        } else if (self._config.placementId) {
+            exec(dispatch, onNativeError, 'Purchasely', 'presentPresentationForPlacement',
+                [self._config.placementId, self._config.contentId || null, normalizedTransition]);
+        } else {
+            exec(dispatch, onNativeError, 'Purchasely', 'presentPresentationForDefault',
+                [self._config.contentId || null, normalizedTransition]);
+        }
+    });
 };
 
-// Purchasely 6.0: present the default (audience-targeted) presentation, with no
-// placement or presentation id (mirrors the native default presentation source).
-exports.presentPresentationForDefault = function (contentId, displayMode, success, error, callbacks) {
-    exec(presentationDispatcher(success, callbacks), error, 'Purchasely', 'presentPresentationForDefault', [contentId, normalizeTransition(displayMode)]);
+// Purchasely 6.0: dismisses via the same native action as the top-level
+// Purchasely.closeAllScreens() / closePresentation() (current bridge semantics:
+// closes every displayed screen, not just this request's).
+PLYPresentationRequest.prototype.close = function () {
+    exports.closeAllScreens();
 };
 
-exports.fetchPresentation = function (presentationId, contentId, success, error) {
-    exec(success, error, 'Purchasely', 'fetchPresentation', [null, presentationId, contentId]);
+// Purchasely 6.0: navigate back within the displayed presentation (was the
+// standalone Purchasely.backPresentation(), now request-scoped).
+PLYPresentationRequest.prototype.back = function () {
+    exec(() => {}, defaultError, 'Purchasely', 'backPresentation', []);
 };
 
-exports.fetchPresentationForPlacement = function (placementId, contentId, success, error) {
-    exec(success, error, 'Purchasely', 'fetchPresentation', [placementId, null, contentId]);
+function PLYPresentationBuilder(config) {
+    this._config = config; // { placementId?, screenId?, contentId?, callbacks }
+}
+
+PLYPresentationBuilder.prototype.contentId = function (id) {
+    this._config.contentId = id;
+    return this;
 };
 
-// Purchasely 6.0: fetch the default (audience-targeted) presentation.
-exports.fetchPresentationForDefault = function (contentId, success, error) {
-    exec(success, error, 'Purchasely', 'fetchPresentation', [null, null, contentId]);
+PLYPresentationBuilder.prototype.onPresented = function (handler) {
+    this._config.callbacks.onPresented = handler;
+    return this;
 };
 
-exports.presentPresentation = function (presentation, displayMode, backgroundColor, success, error, callbacks) {
-    exec(presentationDispatcher(success, callbacks), error, 'Purchasely', 'presentPresentation', [presentation, normalizeTransition(displayMode), backgroundColor]);
+PLYPresentationBuilder.prototype.onCloseRequested = function (handler) {
+    this._config.callbacks.onCloseRequested = handler;
+    return this;
+};
+
+PLYPresentationBuilder.prototype.onDismissed = function (handler) {
+    this._config.callbacks.onDismissed = handler;
+    return this;
+};
+
+PLYPresentationBuilder.prototype.build = function () {
+    return new PLYPresentationRequest(this._config);
+};
+
+// Purchasely 6.0: the v6 presentation builder (parity with the React Native /
+// Flutter Purchasely.presentation). Pick exactly one source, chain
+// .contentId() / .onPresented() / .onCloseRequested() / .onDismissed(), then
+// .build().
+exports.presentation = {
+    placement: function (placementId) {
+        return new PLYPresentationBuilder({ placementId: placementId, callbacks: {} });
+    },
+    screen: function (screenId) {
+        return new PLYPresentationBuilder({ screenId: screenId, callbacks: {} });
+    },
+    defaultSource: function () {
+        return new PLYPresentationBuilder({ callbacks: {} });
+    },
+    // Alias of defaultSource(), kept for parity with the iOS native API name.
+    default: function () {
+        return exports.presentation.defaultSource();
+    }
 };
 
 exports.purchaseWithPlanVendorId = function (planId, offerId, contentId, success, error) {
@@ -288,11 +440,6 @@ exports.closeAllScreens = function (success, error) {
 // platforms already call: Purchasely.closeAllScreens()).
 exports.closePresentation = function (success, error) {
     exports.closeAllScreens(success, error);
-};
-
-// Purchasely 6.0: navigate back within the displayed presentation.
-exports.backPresentation = function () {
-    exec(() => {}, defaultError, 'Purchasely', 'backPresentation', []);
 };
 
 exports.setUserAttributeWithString = function (key, value, processLegalBasis) {

--- a/purchasely/www/Purchasely.js
+++ b/purchasely/www/Purchasely.js
@@ -425,6 +425,11 @@ exports.LogLevel = {
 	ERROR: 3,
 }
 
+// WARNING: this list, iOS's CordovaPLYAttribute typedef, and Android's CordovaPLYAttribute
+// enum class must be kept in strictly identical declaration order across all 3. The bridge
+// matches an attribute by ordinal/symbol POSITION (not by the real native SDK's raw value,
+// which does churn -- see the native PLYAttribute/Attribute enums), so appending a new
+// attribute here always requires the matching append, in the same position, on both natives.
 exports.Attribute = {
   FIREBASE_APP_INSTANCE_ID: 0,
   AIRSHIP_CHANNEL_ID: 1,
@@ -447,10 +452,7 @@ exports.Attribute = {
   MOENGAGE_UNIQUE_ID: 18,
   ONESIGNAL_EXTERNAL_ID: 19,
   BATCH_CUSTOM_USER_ID: 20,
-  // ENM-02 / REC-11: keep this list, iOS's CordovaPLYAttribute, and Android's
-  // CordovaPLYAttribute enum class in strictly identical declaration order -- the bridge
-  // matches by ordinal/symbol position, not by real native raw value.
-  ONESIGNAL_USER_ID: 21,
+  ONESIGNAL_USER_ID: 21, // ENM-02 / REC-11
 }
 
 exports.DataProcessingLegalBasis = {


### PR DESCRIPTION
## Context

Cross-platform parity audit of the v6 Cordova bridge (JS ↔ iOS ObjC ↔ Android Kotlin), against the native iOS/Android SDKs and the sibling Flutter/React Native bridges. This is the Cordova slice of a multi-repo audit (one PR per repo). Maintainer decisions taken during the audit are called out inline below. No `plugin.xml` change was required — all modified sources were already declared.

## BREAKING: v5 presentation surface replaced by the v6 builder API

Maintainer decision: the v5 imperative paywall surface is **removed** (not deprecated) and replaced by the v6 builder, aligned with the React Native/Flutter contract. Eight JS functions are gone — `fetchPresentation`, `fetchPresentationForPlacement`, `fetchPresentationForDefault`, `presentPresentationWithIdentifier`, `presentPresentationForPlacement`, `presentPresentationForDefault`, `presentPresentation`, `backPresentation` — with **zero remaining callers** in `www/`, the example app, or the E2E specs (verified). No new native action is introduced: the builder re-wraps the exact same `exec()` actions the removed functions used.

New surface: `Purchasely.presentation`

```js
Purchasely.presentation.placement(id) | .screen(id) | .defaultSource()   // alias: .default()
  .contentId(id)
  .backgroundColor(hex)
  .onPresented(cb) / .onCloseRequested(cb) / .onDismissed(cb)
  .build()                    // -> PLYPresentationRequest
    .preload()                // -> Promise<loadedPresentation>  (also exposes display()/close()/back())
    .display(transition?)     // -> Promise<outcome>  ({ presentation, purchaseResult, plan, closeReason, error })
    .close()                  // -> closeAllScreens()
    .back()                   // -> navigate back within the displayed presentation
```

Migration table (v5 → v6 builder):

| v5 (removed) | v6 builder |
|---|---|
| `fetchPresentation(id, contentId, ok, err)` | `presentation.screen(id).contentId(contentId).build().preload()` |
| `fetchPresentationForPlacement(id, contentId, ok, err)` | `presentation.placement(id).contentId(contentId).build().preload()` |
| `fetchPresentationForDefault(contentId, ok, err)` | `presentation.defaultSource().contentId(contentId).build().preload()` |
| `presentPresentationWithIdentifier(id, contentId, mode, ok, err, cb)` | `presentation.screen(id).contentId(contentId).onPresented(...).onCloseRequested(...).onDismissed(...).build().display(mode)` |
| `presentPresentationForPlacement(id, contentId, mode, ok, err, cb)` | `presentation.placement(id).contentId(contentId)…build().display(mode)` |
| `presentPresentationForDefault(contentId, mode, ok, err, cb)` | `presentation.defaultSource().contentId(contentId)…build().display(mode)` |
| `presentPresentation(presentation, mode, bg, ok, err, cb)` | `const r = …build(); await r.preload(); await r.display(mode)` (or `loaded.display(mode)`) |
| `backPresentation()` | `request.back()` |

**`screenId` is the sole authoritative public presentation identifier** (supersedes the CDV-W-03 note below). The JS `normalizePresentation` whitelists only the documented presentation fields and resolves `screenId` (tolerating a raw `id` fallback, `screenId ?? id`); the native re-display handle never leaves the request's private `_raw`. On the native side:
- **Android** — `fetchPresentation`'s synthetic re-display handle moved off the public `id` key onto a private `fetchId` key (`presentPresentation` reads `fetchId`, tolerating a legacy `id` fallback for internal belt-and-braces). `screenId` (from `presentationToMap`) is now the only public identifier.
- **iOS** — `id` already equals `screenId`; it is retained only as a private lookup key for `findPresentationLoadedFor:` and is never surfaced to callers (the JS bridge normalizes it away).

Builder modifier parity: `.backgroundColor(hex)` is the only presentation-style modifier the Cordova native layer actually supports (wired to `presentPresentation`'s native background arg on the preload→display path, and to `transition.backgroundColor` on the direct path; iOS-effective, Android applies it only through drawer/popin transitions). RN/Flutter's `progressColor` / `displayCloseButton` / `displayBackButton` are intentionally **not** exposed — no Cordova native present action accepts them (documented in `MIGRATION-v6.md`).

Lifecycle callbacks on both paths, both platforms (asymmetry resolved): `onPresented` / `onCloseRequested` now fire on the `preload()` → `display()` re-display path in addition to the direct `display()` path, on both iOS **and** Android. The earlier Android-only gap (the native builder fixes those callbacks at `build()` time, before `preload()`, when no display invocation exists yet) is fixed: `fetchPresentation` seeds the builder callbacks with closures that resolve the live `CallbackContext` lazily from a handle-keyed `lifecycleCallbacks` map, and `presentPresentation` registers/removes its invocation there. Envelopes are byte-for-byte identical to the direct path; the entry is cleaned up on the dismiss outcome and on the activity-null early return (display failures are delivered by the native SDK through the outcome callback, which also cleans up). iOS already assigned these per invocation before `displayFrom:` — no iOS change. The final dismiss outcome always resolves on both platforms.

## Critical fixes

- **CDV-W-01 — iOS event stream crash on nil properties.** `eventTriggered:properties:` declares `properties` as `_Nullable`; the JS payload was built with an ObjC dictionary **literal**, which throws `NSInvalidArgumentException` when the SDK fires an event with nil properties. Now built with `NSMutableDictionary`, setting `properties` only when non-nil.
- **CDV-W-02 — iOS `signPromotionalOffer` dropped the whole signature.** Success path called `successFor:resultBool:` with an `NSDictionary*` (implicitly truncated to a bare `BOOL`), so JS received `true` instead of the signature payload (planVendorId/identifier/signature/keyIdentifier/nonce/timestamp). Switched to the matching `successFor:resultDict:` overload.
- **CDV-W-03 — presentation id key divergence.** Android's `presentationToMap()` emits `screenId`; iOS emitted only `id`. iOS now emits **both** `screenId` and `id`. _Superseded by the BREAKING section above:_ `screenId` is now the sole authoritative public identifier on both platforms, Android's synthetic handle was moved from `id` to the private `fetchId`, and iOS's `id` is kept only as a private lookup key.

## Behavior changes to highlight (maintainer decisions)

- **`closePresentation` → alias of `closeAllScreens`** (explicit maintainer decision). `closeAllScreens` is now the canonical JS name; `closePresentation` is a deprecated alias that calls it. Verified an alias on **both** platforms: the JS alias dispatches the `closeAllScreens` native action, and on each platform that action calls `Purchasely.closeAllScreens()` and resolves the callback.
- **`normalizeTransition` no longer forces `fullScreen`.** When no `displayMode` is passed, JS now sends `undefined` instead of a synthetic `{ type: 'fullScreen' }`. Both native handlers return nil/null for an absent transition (`displayModeFromTransition` on iOS, `transitionFromMap` on Android), so the **backend-configured** placement/screen transition is honored — as the native layer was already written to support.
- **`invalidateCache` default on Android flipped `true` → `false`** for `userSubscriptions`/`userSubscriptionsHistory`. It was hardcoded `true` on Android (always a fresh fetch); it is now an optional JS argument defaulting to `false`, aligning with iOS/native. Behavior change for Android callers that relied on the implicit fresh fetch.
- **`signPromotionalOffer` on Android is now a no-op success** instead of an error (`"No signing required on Android"`). Promotional-offer signing is iOS-only (StoreKit); resolving success lets shared JS call it unconditionally on both platforms without special-casing Android (REC-04).

## New APIs

- **v6 presentation builder (`Purchasely.presentation`)** — see the BREAKING section above.
- **Dynamic Offerings (PAR-05):** `setDynamicOffering`, `getDynamicOfferings`, `removeDynamicOffering`, `clearDynamicOfferings`. Payload keys (`reference`/`planVendorId`/`offerVendorId`) match the Flutter/RN contract, not the native SDK's own property names.
- **`incrementUserAttribute` / `decrementUserAttribute` (PAR-02):** value defaults to 1 natively when omitted.
- **`userAttributes()` bulk read (PAR-03):** same per-value type conversions as the single-key `userAttribute(key)` read (including the Double/Float and Boolean fixes below).
- **`isAnonymous()` (PAR-04).**
- **`getBuiltInAttributes()` / `getBuiltInAttribute(key)` (PAR-07).**
- **`userLogout(clearUserAttributes)` (PAR-30):** defaults to `true` on both platforms.
- **`addEventListener` / `removeEventListener` (REC-18):** canonical names matching RN; `addEventsListener`/`removeEventsListener` kept as deprecated aliases.

## Fixes (short)

- **CDV-W-05** — Android now omits the `plan` key when there is no plan (was `{}`, truthy), matching iOS. Only `plan` was changed.
- **CDV-W-06** — Android `userAttribute` now has an `is Double ->` branch, so reading back a `setUserAttributeWithDouble` value no longer errors.
- **CDV-W-07** — Android present*/presentPresentation now resolve the dismiss outcome against **each invocation's own** `callbackContext` (removed the single companion `purchaseCallback` slot + `sendPurchaseResult`), so overlapping presentations can no longer cross-wire — matching iOS's per-invocation closure capture. All paths covered: `onPresented`/`onCloseRequested` keep-alive envelopes, dismiss outcome, the catch/error path, and the re-display path (which now fails cleanly with an error instead of silently no-op-ing when there is no activity). The default dismiss handler (`setDefaultPresentationDismissHandler`) is unchanged and independent.
- **CDV-W-09** — Android `userAttribute` returns a real JSON boolean (was `0`/`1`), matching iOS.
- **CDV-W-11** — removed the dead, unreachable Android `"close"` execute() case.
- **CDV-W-13** — Android `setLogLevel` reuses the bounded `logLevelFrom()` helper instead of `LogLevel.values()[i]` (was an uncaught `ArrayIndexOutOfBoundsException` on out-of-range input).
- **CDV-W-14** — iOS `purchasedSubscription` removes any prior `NSNotificationCenter` observer before re-adding, so a repeat JS call no longer stacks duplicate `reloadContent:` firings.
- **CDV-W-15** — Android maps `StoreType.NONE` / `StoreType.WEB_CHECKOUT_STRIPE` to subscriptionSource `4` (`none`), matching iOS's `PLYSubscriptionSource.None`.
- **ENM-02** — appended `ONESIGNAL_USER_ID` to the JS/iOS/Android attribute lists (all three kept in identical declaration order; the bridge maps by ordinal position, not by the native SDK's churning raw value).
- **rc.4 hardening** — `normalizePlanTypeOrdinal` tolerates both the current ordinal-Int and the upcoming DistributionType-name-String form of `PLYPlan.toMap()`'s `type`, keeping the JS `PlanType` (ordinal) contract stable across `allProducts`/`productWithIdentifier`/nested subscription product maps.

## Platform limitation note

- **PAR-06** — added a README "Limitations" section documenting that inline/embedded paywall views (`PLYPresentationView`/`getFragment`) are not available on Cordova (only modal/fullscreen presentation). Embedding a native view inside the WebView is not supported by this bridge architecture — an accepted platform limitation, not a bug.

## Rejected (out of scope by maintainer decision, verified untouched)

`silentRestoreAllProducts` behavior divergence (CDV-W-04); null-vs-omitted key differences outside `plan` (CDV-W-10); batch `setUserAttributes`; `getSDKVersion`/`addLogger`; transition string casing; no OneSignal `playerId` attribute added.

## Tests

- **Jest: 118/118 passing** (`cd purchasely && npm test`). The presentation suite was rewritten for the v6 builder (sources, contentId, transitions, lifecycle callbacks, 5-field outcome normalization with `screenId` tolerance, preload→display re-display, direct display, and removed-v5-surface guards), plus new tests for the loaded-presentation `display()/close()/back()` methods, `.backgroundColor()` on both display paths, and a regression test asserting `onPresented`/`onCloseRequested` fire on the `preload()` → `display()` path with the Promise resolving only at the final outcome envelope. The `presented` envelope's presentation is now `screenId`-normalized like every other presentation exposure (no `fetchId`/`id` leak).
- **Native builds not run locally** (iOS Pods not installed in the worktree; no standalone Android Gradle module). Every new/changed native selector was cross-checked against the actual vendored iOS v6 SDK header (`Purchasely-Swift.h`: `incrementUserAttributeWithKey:value:` 2-arg overload, `isAnonymous`, `setDynamicOfferingWithReference:...`, `getDynamicOfferingsWithCompletion:`, `getBuiltInAttribute(s)`, `userAttributes`, `PLYOffering.reference/planId/offerId`, `PLYBillingPlanTypeUnspecified`, `PLYAttributeOneSignalUserId = 22`, `userLoginWith:` Nonnull) and the Android SDK source (`Purchasely.kt` facade signatures, `Enums.kt` `StoreType.WEB_CHECKOUT_STRIPE`/`NONE`, `Attribute.ONESIGNAL_USER_ID`, `PLYDynamicOffering.reference/planId/offerId`). CI will build both platforms.
- **E2E specs + example app migrated to the v6 builder** (and bridge int/boolean attribute round-trips + `userSubscriptions`; default-presentation dismiss) but **not executed** — they require a device/emulator and the real backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

