### PR TITLE
feat: parité commitment Apple (iOS 26.4+) dans le bridge Cordova

### DIFF
--- a/MIGRATION-v6.md
+++ b/MIGRATION-v6.md
@@ -281,7 +281,44 @@ callback) exposes:
 ## 8. New exported constants
 
 `InterceptResult`, `PresentationType`, `CloseReason`, `TransitionType`, `DimensionType`,
-`Store`, `StorekitVersion`, `PresentationAction`.
+`Store`, `StorekitVersion`, `PresentationAction`, `BillingPlanType`.
+
+## 9. Apple commitment info (iOS 26.4+, Apple only)
+
+Apple's "monthly subscription with 12-month commitment" is now surfaced through the bridge.
+These fields are **iOS-only** — they are absent on Android and on plans/subscriptions without
+a commitment, so read them defensively.
+
+- **`Purchasely.BillingPlanType`** — `{ unspecified: 0, upFront: 1, monthly: 2 }`. Pass it as
+  the new 4th argument of `setDynamicOffering(reference, planVendorId, offerVendorId,
+  billingPlanType, success, error)` (defaults to `unspecified` when omitted).
+
+- **`plan.commitmentInfo`** — an array present on plans returned by `allProducts()` /
+  `planWithIdentifier()`, on a presentation outcome's `plan`, and on the
+  `interceptAction('purchase')` payload's `parameters.plan`. Each entry:
+
+  ```js
+  {
+    billingPlanType, // Number — see Purchasely.BillingPlanType
+    billingPrice,    // Number — per-cycle price
+    billingPeriod,   // String — ISO 8601 duration, e.g. "P1M"
+    totalPrice,      // Number — total over the full commitment
+    totalPeriod,     // String — ISO 8601 duration, e.g. "P1Y"
+    totalDuration    // Number — number of billing cycles (e.g. 12)
+  }
+  ```
+
+- **`subscription.commitmentProgress`** — present on subscriptions returned by
+  `userSubscriptions()` / `userSubscriptionsHistory()`:
+
+  ```js
+  {
+    billingPeriodNumber,   // Number — current billing period (1-based)
+    totalBillingPeriods,   // Number — total periods in the commitment
+    commitmentExpiresDate, // String — ISO 8601 date
+    commitmentPrice        // Number — price for this period
+  }
+  ```
 
 ---
 

--- a/purchasely/__tests__/Purchasely.test.js
+++ b/purchasely/__tests__/Purchasely.test.js
@@ -99,6 +99,14 @@ describe('Purchasely', () => {
       });
     });
 
+    describe('BillingPlanType', () => {
+      it('should have correct billing plan type values (iOS 26.4+ commitment, Apple only)', () => {
+        expect(Purchasely.BillingPlanType.unspecified).toBe(0);
+        expect(Purchasely.BillingPlanType.upFront).toBe(1);
+        expect(Purchasely.BillingPlanType.monthly).toBe(2);
+      });
+    });
+
     describe('RunningMode', () => {
       it('should expose the Purchasely 6.0 running modes by name', () => {
         expect(Purchasely.RunningMode.observer).toBe('observer');
@@ -1064,6 +1072,37 @@ describe('Purchasely', () => {
       );
     });
 
+    // Commitment fields (iOS 26.4+, Apple only) ride on the plan carried by the purchase
+    // payload's `parameters.plan`. The JS layer forwards `parameters` verbatim, so a plan's
+    // `commitmentInfo` must survive untouched — this guards against a future param whitelist
+    // silently dropping it.
+    it('forwards a purchase payload plan carrying commitmentInfo to the handler', async () => {
+      const handler = jest.fn().mockReturnValue(Purchasely.InterceptResult.success);
+      Purchasely.interceptAction('purchase', handler);
+      const nativeSuccess = nativeInterceptorFor('purchase');
+
+      const parameters = {
+        plan: {
+          vendorId: 'plan_monthly_12m',
+          commitmentInfo: [
+            {
+              billingPlanType: Purchasely.BillingPlanType.monthly,
+              billingPrice: 9.99,
+              billingPeriod: 'P1M',
+              totalPrice: 119.88,
+              totalPeriod: 'P1Y',
+              totalDuration: 12,
+            },
+          ],
+        },
+      };
+      nativeSuccess({ action: 'purchase', callbackId: 'purchase#c', info: null, parameters });
+      await flush();
+
+      expect(handler).toHaveBeenCalledWith(null, parameters);
+      expect(handler.mock.calls[0][1].plan.commitmentInfo[0].billingPlanType).toBe(2);
+    });
+
     it('ignores events whose action does not match the registered kind', async () => {
       const handler = jest.fn();
       Purchasely.interceptAction('restore', handler);
@@ -1577,30 +1616,30 @@ describe('Purchasely', () => {
 
   describe('Dynamic Offerings (PAR-05)', () => {
     describe('setDynamicOffering', () => {
-      it('should call exec with correct parameters', () => {
+      it('should call exec with correct parameters, forwarding billingPlanType', () => {
         const success = jest.fn();
         const error = jest.fn();
 
-        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', 'offer_vendor_id', success, error);
+        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', 'offer_vendor_id', Purchasely.BillingPlanType.monthly, success, error);
 
         expect(mockExec).toHaveBeenCalledWith(
           success,
           error,
           'Purchasely',
           'setDynamicOffering',
-          ['ref_1', 'plan_vendor_id', 'offer_vendor_id']
+          ['ref_1', 'plan_vendor_id', 'offer_vendor_id', 2]
         );
       });
 
-      it('should forward a null offerVendorId when none is given', () => {
-        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', null, jest.fn(), jest.fn());
+      it('should forward a null offerVendorId and default billingPlanType to unspecified when omitted', () => {
+        Purchasely.setDynamicOffering('ref_1', 'plan_vendor_id', null, undefined, jest.fn(), jest.fn());
 
         expect(mockExec).toHaveBeenCalledWith(
           expect.any(Function),
           expect.any(Function),
           'Purchasely',
           'setDynamicOffering',
-          ['ref_1', 'plan_vendor_id', null]
+          ['ref_1', 'plan_vendor_id', null, 0]
         );
       });
     });

--- a/purchasely/src/ios/CDVPurchasely.m
+++ b/purchasely/src/ios/CDVPurchasely.m
@@ -593,11 +593,14 @@
     if (![offerVendorId isKindOfClass:[NSString class]]) {
         offerVendorId = nil;
     }
+    // iOS 26.4+ Apple commitment billing plan type (0 unspecified / 1 upFront / 2 monthly);
+    // JS defaults it to unspecified when omitted (see Purchasely.BillingPlanType).
+    PLYBillingPlanType billingPlanType = [[command argumentAtIndex:3 withDefault:@(PLYBillingPlanTypeUnspecified)] integerValue];
 
     [Purchasely setDynamicOfferingWithReference:reference
                                     planVendorId:planVendorId
                                    offerVendorId:offerVendorId
-                                 billingPlanType:PLYBillingPlanTypeUnspecified
+                                 billingPlanType:billingPlanType
                                       completion:^(BOOL success) {
         [self successFor:command resultBool:success];
     }];

--- a/purchasely/src/ios/Hybrid/PLYPlan+Hybrid.m
+++ b/purchasely/src/ios/Hybrid/PLYPlan+Hybrid.m
@@ -79,6 +79,25 @@
 		[dict setObject:introPeriod forKey:@"introPeriod"];
 	}
 
+	// Commitment installment details (iOS 26.4+ multi-period commitments, e.g. "monthly
+	// subscription with 12-month commitment"). Apple-only: the array is empty for every other
+	// plan, so the key is omitted then. Mirrors PLYPlan.commitmentInfo: [PLYCommitmentInfo].
+	NSArray<PLYCommitmentInfo *> *commitmentInfo = self.commitmentInfo;
+	if (commitmentInfo.count > 0) {
+		NSMutableArray<NSDictionary *> *commitmentArray = [NSMutableArray new];
+		for (PLYCommitmentInfo *info in commitmentInfo) {
+			[commitmentArray addObject:@{
+				@"billingPlanType": @(info.billingPlanType),
+				@"billingPrice":    info.billingPrice,
+				@"billingPeriod":   info.billingPeriod,
+				@"totalPrice":      info.totalPrice,
+				@"totalPeriod":     info.totalPeriod,
+				@"totalDuration":   @(info.totalDuration)
+			}];
+		}
+		[dict setObject:commitmentArray forKey:@"commitmentInfo"];
+	}
+
 	return dict;
 }
 

--- a/purchasely/src/ios/Hybrid/PLYSubscription+Hybrid.m
+++ b/purchasely/src/ios/Hybrid/PLYSubscription+Hybrid.m
@@ -28,6 +28,19 @@
 		[dict setObject:[dateFormat stringFromDate:self.cancelledDate] forKey:@"cancelledDate"];
 	}
 
+	// Commitment progress (iOS 26.4+ monthly commitment, e.g. billing period 3 of 12).
+	// Apple-only and nil for every non-committed subscription, so the key is omitted then.
+	// Mirrors PLYSubscription.commitmentProgress: PLYCommitmentProgress?
+	PLYCommitmentProgress *commitmentProgress = self.commitmentProgress;
+	if (commitmentProgress != nil) {
+		[dict setObject:@{
+			@"billingPeriodNumber":   @(commitmentProgress.billingPeriodNumber),
+			@"totalBillingPeriods":   @(commitmentProgress.totalBillingPeriods),
+			@"commitmentExpiresDate": [dateFormat stringFromDate:commitmentProgress.commitmentExpiresDate],
+			@"commitmentPrice":       commitmentProgress.commitmentPrice
+		} forKey:@"commitmentProgress"];
+	}
+
 	return dict;
 }
 

--- a/purchasely/www/Purchasely.js
+++ b/purchasely/www/Purchasely.js
@@ -565,8 +565,27 @@ exports.isAnonymous = function (success, error) {
 
 // PAR-05: Dynamic Offerings -- force a specific plan (and optionally offer) to be shown
 // in a specific context, keyed by an app-chosen reference.
-exports.setDynamicOffering = function (reference, planVendorId, offerVendorId, success, error) {
-    exec(success || (() => {}), error || defaultError, 'Purchasely', 'setDynamicOffering', [reference, planVendorId, offerVendorId]);
+// Purchasely 6.0 (iOS 26.4+, Apple only): billing plan type of a subscription with a
+// multi-period commitment (e.g. "monthly subscription with 12-month commitment"). Passed to
+// setDynamicOffering and surfaced on the commitment fields below. Android always reports
+// `unspecified`.
+exports.BillingPlanType = { unspecified: 0, upFront: 1, monthly: 2 };
+
+// Purchasely 6.0 commitment fields (iOS 26.4+ only; absent on Android and on plans without a
+// commitment):
+//  - A plan object (from allProducts()/planWithIdentifier(), a presentation outcome's `plan`,
+//    and the interceptAction('purchase') `parameters.plan`) may carry `commitmentInfo`: an
+//    array of { billingPlanType (Number, see Purchasely.BillingPlanType), billingPrice
+//    (Number), billingPeriod (ISO 8601 duration string, e.g. "P1M"), totalPrice (Number),
+//    totalPeriod (ISO 8601 duration string, e.g. "P1Y"), totalDuration (Number of billing
+//    cycles) }.
+//  - A subscription object (from userSubscriptions()/userSubscriptionsHistory()) may carry
+//    `commitmentProgress`: { billingPeriodNumber (Number), totalBillingPeriods (Number),
+//    commitmentExpiresDate (ISO 8601 date string), commitmentPrice (Number) }.
+exports.setDynamicOffering = function (reference, planVendorId, offerVendorId, billingPlanType, success, error) {
+    exec(success || (() => {}), error || defaultError, 'Purchasely', 'setDynamicOffering',
+        [reference, planVendorId, offerVendorId != null ? offerVendorId : null,
+         billingPlanType != null ? billingPlanType : 0]);
 };
 
 // Returns a list of { reference, planVendorId, offerVendorId }.


### PR DESCRIPTION
## Contexte

Le SDK iOS natif Purchasely v6 expose le support Apple **« monthly subscription with 12-month commitment »** (iOS 26.4+) via une API publique (`PLYPlan.commitmentInfo`, `PLYSubscription.commitmentProgress`, enum `PLYBillingPlanType`). Le bridge Cordova ne l'exposait pas encore. Cette PR comble ce trou de parité **côté Cordova uniquement** (feature **Apple-only**).

## Fichiers modifiés

- **`purchasely/src/ios/Hybrid/PLYPlan+Hybrid.m`** — sérialise `PLYPlan.commitmentInfo` (tableau) sous la clé `commitmentInfo`. Point de marshaling unique du plan → couvre automatiquement `allProducts`, `planWithIdentifier`, `productWithIdentifier` (plans imbriqués), `outcome.plan`, et le payload `parameters.plan` de `interceptAction('purchase')`.
- **`purchasely/src/ios/Hybrid/PLYSubscription+Hybrid.m`** — sérialise `PLYSubscription.commitmentProgress` sous la clé `commitmentProgress` (date en ISO 8601 via le `dateFormat` déjà présent). Couvre `userSubscriptions` / `userSubscriptionsHistory`.
- **`purchasely/src/ios/CDVPurchasely.m`** — `setDynamicOffering` lit et transmet le vrai `billingPlanType` (argument index 3) au lieu de forcer `PLYBillingPlanTypeUnspecified`.
- **`purchasely/www/Purchasely.js`** — ajout de `Purchasely.BillingPlanType`, nouvel argument `billingPlanType` sur `setDynamicOffering`, et documentation des champs commitment (plan, subscription, payload purchase).
- **`purchasely/__tests__/Purchasely.test.js`** — tests de la constante, du forwarding/défaut de `billingPlanType`, et du pass-through de `commitmentInfo` sur le payload purchase.
- **`MIGRATION-v6.md`** — section « Apple commitment info (iOS 26.4+, Apple only) ».

## Forme exacte des payloads exposés

Plan (`plan.commitmentInfo`, présent uniquement si commitment) :
```json
"commitmentInfo": [
  { "billingPlanType": 2, "billingPrice": 9.99, "billingPeriod": "P1M",
    "totalPrice": 119.88, "totalPeriod": "P1Y", "totalDuration": 12 }
]
```

Subscription (`subscription.commitmentProgress`, présent uniquement si non-nil) :
```json
"commitmentProgress": {
  "billingPeriodNumber": 3, "totalBillingPeriods": 12,
  "commitmentExpiresDate": "2026-07-20T10:00:00+0000", "commitmentPrice": 9.99
}
```

Payload purchase de `interceptAction('purchase')` : le `commitmentInfo` ci-dessus est porté par `parameters.plan`.

## Validation

- **`npm test`** (dossier `purchasely/`) : **120 passed, 120 total**, 0 échec.
- **Build iOS local** : `cordova build ios --emulator` (miroir de la CI) → **BUILD SUCCEEDED** contre le pod `Purchasely 6.0.0-rc.3`. Les objets `PLYPlan+Hybrid.o`, `PLYSubscription+Hybrid.o` et `CDVPurchasely.o` sont bien compilés (arm64 + x86_64) et linkés dans l'app. Seul un warning pré-existant du pod (deployment target 11.0 vs 12.0), sans rapport avec ces changements.
- **Note CI iOS** : `ci.yml` job `build-ios` (macos-15, `cordova build ios --emulator`) couvre bien la compilation iOS, mais son trigger `pull_request` est limité à `main`/`master`. Une PR ciblant `fix/v6-audit-remediation` ne déclenchera donc pas la CI automatiquement (elle reste lançable via `workflow_dispatch`). Le build local ci-dessus fournit la preuve de compilation en attendant.

## Notes

- **Android null-safe** : aucune modification. Le bridge Android sérialise via les `toMap()` natifs, qui n'émettent pas ces clés (feature Apple-only) → `undefined` côté JS, sans casse. Aucune clé requise.
- **Convention wire `billingPlanType`** : côté Cordova le type est transporté en **entier** (`0` unspecified / `1` upFront / `2` monthly) via `Purchasely.BillingPlanType`, cohérent avec l'enum natif `PLYBillingPlanType` et le reste des enums exposés en Cordova. Choix de convention par-bridge intentionnel.
- **`commitmentPrice`** : conservé dans `commitmentProgress` (présent dans l'API du pod), en plus des 3 champs de base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)